### PR TITLE
后台优化（批量上传/适配移动端/样式优化）

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -4,6 +4,24 @@ Free Image Hosting solution, Flickr/imgur alternative. Using Cloudflare Pages an
 
 English|[中文](readme-zh.md)
 
+Use tg channel/chat for storage
+
+How to use?
+
+First, you need to create a new telegram bot to obtain the token and a telegram channel to obtain Chat_ID
+## How to Obtain `Bot_Token` and `Chat_ID` for Telegram
+
+If you don't have a Telegram account yet, please create one first. Then, follow these steps to get the `Bot_Token` and `Chat_ID`:
+
+1. **Get the `Bot_Token`**
+   - In Telegram, send the command `/newbot` to [@BotFather](https://t.me/BotFather), and follow the prompts to input your bot's name and username. Once successfully created, you will receive a `Bot_Token`, which is used to interact with the Telegram API.
+
+2. **Set the bot as a channel administrator**
+   - Create a new channel and, after entering the channel, go to channel settings. Add the bot you just created as a channel administrator, so it can send messages.
+
+3. **Get the `Chat_ID`**
+   - Use [@GetTheirIDBot](https://t.me/GetTheirIDBot) to get your channel ID. Send a message to this bot and follow the instructions to receive your `Chat_ID` (the ID of your channel).
+   
 ## Deployment
 
 ### Preparation

--- a/README.md
+++ b/README.md
@@ -4,6 +4,38 @@
 
 [English](README-EN.md)|中文
 
+> [!IMPORTANT]
+>
+> 由于原有的Telegraph API接口被官方关闭，需要将上传渠道切换至Telegram Channel，请按照文档中的部署要求设置`TG_Bot_Token`和`TG_Chat_ID`，否则将无法正常使用上传功能。
+
+## 如何获取Telegram的`Bot_Token`和`Chat_ID`
+
+如果您还没有Telegram账户，请先创建一个。接着，按照以下步骤操作以获取`BOT_TOKEN`和`CHAT_ID`：
+
+1. **获取`Bot_Token`**
+   - 在Telegram中，向[@BotFather](https://t.me/BotFather)发送命令`/newbot`，根据提示依次输入您的机器人名称和用户名。成功创建机器人后，您将会收到一个`BOT_TOKEN`，用于与Telegram API进行交互。
+   
+![202409071744569](https://github.com/user-attachments/assets/04f01289-205c-43e0-ba03-d9ab3465e349)
+
+2. **设置机器人为频道管理员**
+   - 创建一个新的频道（Channel），进入该频道后，选择频道设置。将刚刚创建的机器人添加为频道管理员，这样机器人才能发送消息。
+
+![202409071758534](https://github.com/user-attachments/assets/cedea4c7-8b31-42e0-98a1-8a72ff69528f)
+   
+![202409071758796](https://github.com/user-attachments/assets/16393802-17eb-4ae4-a758-f0fdb7aaebc4)
+
+
+3. **获取`Chat_ID`**
+   - 通过[@VersaToolsBot](https://t.me/VersaToolsBot)获取您的频道ID。向该机器人发送消息，按照指示操作，最后您将得到`CHAT_ID`（即频道的ID）。
+   - 或者通过[@GetTheirIDBot](https://t.me/GetTheirIDBot)获取您的频道ID。向该机器人发送消息，按照指示操作，最后您将得到`CHAT_ID`（即频道的ID）。
+
+   ![202409071751619](https://github.com/user-attachments/assets/59fe8b20-c969-4d13-8d46-e58c0e8b9e79)
+
+最后去Cloudflare Pages后台设置相关的环境变量（注：修改环境变量后，需要重新部署才能生效）
+| 环境变量        | 示例值                    | 说明                                                                                   |
+|-----------------|---------------------------|----------------------------------------------------------------------------------------|
+| `TG_Bot_Token`   | `123468:AAxxxGKrn5`        | 从[@BotFather](https://t.me/BotFather)获取的Telegram Bot Token。                        |
+| `TG_Chat_ID`     | `-1234567`                 | 频道的ID，确保TG Bot是该频道或群组的管理员。 |
 
 ## 如何部署
 

--- a/admin-imgtc.html
+++ b/admin-imgtc.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="zh">
+
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -45,7 +46,8 @@
     }
 
     .title:hover {
-      color: #B39DDB; /* 使用柔和的淡紫色 */
+      color: #B39DDB;
+      /* 使用柔和的淡紫色 */
     }
 
     .search-card {
@@ -74,13 +76,16 @@
     }
 
     .stats:hover {
-      background-color: #f0eaf8; /* 使用柔和的淡紫色 */
+      background-color: #f0eaf8;
+      /* 使用柔和的淡紫色 */
       box-shadow: 0 4px 6px rgba(0, 0, 0, 0.15);
-      color: #B39DDB; /* 使用柔和的淡紫色 */
+      color: #B39DDB;
+      /* 使用柔和的淡紫色 */
     }
 
     .stats:hover .fa-database {
-      color: #B39DDB; /* 使用柔和的淡紫色 */
+      color: #B39DDB;
+      /* 使用柔和的淡紫色 */
     }
 
     .header-content .actions {
@@ -97,7 +102,8 @@
     }
 
     .header-content .actions i:hover {
-      color: #B39DDB; /* 使用柔和的淡紫色 */
+      color: #B39DDB;
+      /* 使用柔和的淡紫色 */
       transform: scale(1.2);
     }
 
@@ -106,7 +112,8 @@
     }
 
     .header-content .actions .el-dropdown-link i:hover {
-      color: #B39DDB; /* 使用柔和的淡紫色 */
+      color: #B39DDB;
+      /* 使用柔和的淡紫色 */
     }
 
     .header-content .actions .disabled {
@@ -115,7 +122,8 @@
     }
 
     .header-content .actions .enabled {
-      color: #B39DDB; /* 使用柔和的淡紫色 */
+      color: #B39DDB;
+      /* 使用柔和的淡紫色 */
     }
 
     .search-card .el-input__inner {
@@ -229,6 +237,7 @@
     }
   </style>
 </head>
+
 <body>
   <div id="app">
     <el-container>
@@ -248,8 +257,10 @@
                   <i :class="sortIcon"></i>
                 </span>
                 <el-dropdown-menu slot="dropdown">
-                  <el-dropdown-item command="dateDesc" :class="{ 'el-dropdown-menu__item--selected': sortOption === 'dateDesc' }">按时间倒序</el-dropdown-item>
-                  <el-dropdown-item command="nameAsc" :class="{ 'el-dropdown-menu__item--selected': sortOption === 'nameAsc' }">按名称升序</el-dropdown-item>
+                  <el-dropdown-item command="dateDesc"
+                    :class="{ 'el-dropdown-menu__item--selected': sortOption === 'dateDesc' }">按时间倒序</el-dropdown-item>
+                  <el-dropdown-item command="nameAsc"
+                    :class="{ 'el-dropdown-menu__item--selected': sortOption === 'nameAsc' }">按名称升序</el-dropdown-item>
                 </el-dropdown-menu>
               </el-dropdown>
             </el-tooltip>
@@ -257,7 +268,8 @@
               <i class="fas fa-link" :class="{ disabled: selectedFiles.length === 0 }" @click="handleBatchCopy"></i>
             </el-tooltip>
             <el-tooltip content="批量删除" placement="bottom">
-              <i class="fas fa-trash-alt" :class="{ disabled: selectedFiles.length === 0 }" @click="handleBatchDelete"></i>
+              <i class="fas fa-trash-alt" :class="{ disabled: selectedFiles.length === 0 }"
+                @click="handleBatchDelete"></i>
             </el-tooltip>
             <el-tooltip content="退出登录" placement="bottom">
               <i class="fas fa-home" @click="handleLogout"></i>
@@ -270,10 +282,7 @@
           <template v-for="(item, index) in paginatedTableData" :key="index">
             <el-card>
               <el-checkbox v-model="item.selected"></el-checkbox>
-              <el-image
-                :src="'/file/' + item.name"
-                :preview-src-list="['/file/' + item.name]"
-                fit="cover"
+              <el-image :src="'/file/' + item.name" :preview-src-list="['/file/' + item.name]" fit="cover"
                 lazy></el-image>
               <div class="image-overlay">
                 <div class="overlay-buttons">
@@ -286,13 +295,8 @@
           </template>
         </div>
         <div class="pagination-container">
-          <el-pagination
-            background
-            layout="prev, pager, next"
-            :total="filteredTableData.length"
-            :page-size="pageSize"
-            @current-change="handlePageChange"
-            :current-page.sync="currentPage">
+          <el-pagination background layout="prev, pager, next" :total="filteredTableData.length" :page-size="pageSize"
+            @current-change="handlePageChange" :current-page.sync="currentPage">
           </el-pagination>
         </div>
       </el-main>
@@ -428,7 +432,15 @@
       mounted() {
         fetch("./api/manage/check", { method: 'GET', credentials: 'include' })
           .then(response => response.text())
-          .then(result => result === "true" ? this.showLogoutButton = true : window.location.href = "./api/manage/login")
+          .then(result => {
+            if (result == "true") {
+              this.showLogoutButton = true;
+            } else if (result == "Not using basic auth.") {
+              // Do nothing
+            } else {
+              window.location.href = "./api/manage/login";
+            }
+          })
           .catch(() => this.$message.error('同步数据时出错，请检查网络连接'));
 
         fetch("./api/manage/list", { method: 'GET', credentials: 'include' })
@@ -447,4 +459,5 @@
     });
   </script>
 </body>
+
 </html>

--- a/admin-imgtc.html
+++ b/admin-imgtc.html
@@ -1,308 +1,381 @@
-<!DOCTYPE html>
-<html lang="zh">
-
+  <!DOCTYPE html>
+  <html lang="zh">
+  
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>ImgTC | Admin</title>
-  <!-- Import CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/element-ui@2.15.3/lib/theme-chalk/index.css">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free/css/all.min.css">
-  <script src="https://js.sentry-cdn.com/219f636ac7bde5edab2c3e16885cb535.min.js" crossorigin="anonymous"></script>
-  <style>
-    body {
-      background: linear-gradient(90deg, #ffd7e4 0%, #c8f1ff 100%);
-      font-family: 'Arial', sans-serif;
-      color: #333;
-      margin: 0;
-      padding: 0;
-    }
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>ImgTC | Admin</title>
+    <!-- Import CSS -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/element-ui@2.15.3/lib/theme-chalk/index.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free/css/all.min.css">
+    <script src="https://js.sentry-cdn.com/219f636ac7bde5edab2c3e16885cb535.min.js" crossorigin="anonymous"></script>
+    <style>
+      body {
+        background: linear-gradient(90deg, #ffd7e4 0%, #c8f1ff 100%);
+        font-family: 'Arial', sans-serif;
+        color: #333;
+        margin: 0;
+        padding: 0;
+      }
 
-    .header-content {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      padding: 10px 20px;
-      background-color: rgba(255, 255, 255, 0.75);
-      backdrop-filter: blur(10px);
-      border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-      box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-      transition: background-color 0.5s ease, box-shadow 0.5s ease;
-      border-bottom-left-radius: 10px;
-      border-bottom-right-radius: 10px;
-    }
+      .header-content {
+        position: fixed;
+        top: 0;
+        left: 1%;
+        right: 1%;
+        z-index: 999;
+        height: clamp(40px, 8vh, 60px);
+        display: flex;
+        align-items: center;
+        padding: 10px 20px;
+        background-color: rgba(255, 255, 255, 0.75);
+        -webkit-backdrop-filter: blur(10px);
+        backdrop-filter: blur(10px);
+        border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+        box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+        transition: background-color 0.5s ease, box-shadow 0.5s ease;
+        border-bottom-left-radius: 10px;
+        border-bottom-right-radius: 10px;
+      }
 
-    .header-content:hover {
-      background-color: rgba(255, 255, 255, 0.85);
-      box-shadow: 0 6px 10px rgba(0, 0, 0, 0.2);
-    }
+      .header-content:hover {
+        background-color: rgba(255, 255, 255, 0.85);
+        box-shadow: 0 6px 10px rgba(0, 0, 0, 0.2);
+      }
 
-    .title {
-      font-size: 1.8em;
-      font-weight: bold;
-      cursor: pointer;
-      transition: color 0.3s ease;
-      color: #333;
-    }
+      .title {
+        font-size: clamp(1.2em, 2vw, 1.8em);
+        font-weight: bold;
+        cursor: pointer;
+        transition: color 0.3s ease;
+        margin-right: 4px;
+        color: #333;
+      }
 
-    .title:hover {
-      color: #B39DDB;
-      /* 使用柔和的淡紫色 */
-    }
+      .title:hover {
+        color: #B39DDB; /* 使用柔和的淡紫色 */
+      }
 
-    .search-card {
-      margin-left: auto;
-      margin-right: 20px;
-    }
+      .search-card {
+        margin-left: auto;
+        margin-right: 16px;
+      }
 
-    .stats {
-      font-size: 1.2em;
-      margin-right: 20px;
-      display: flex;
-      align-items: center;
-      background: rgba(255, 255, 255, 0.9);
-      padding: 5px 10px;
-      border-radius: 10px;
-      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-      transition: background-color 0.3s ease, box-shadow 0.3s ease;
-      color: #333;
-    }
+      .stats {
+        display: flex;
+        align-items: center;
+        cursor: pointer;
+        font-size: clamp(0.9em, 1.5vw, 1.2em);
+        background: rgba(255, 255, 255, 0.9);
+        margin-right: 8px;
+        padding: 2px 8px;
+        border-radius: 12px;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+        transition: background-color 0.3s ease, box-shadow 0.3s ease, transform 0.3s ease;
+        color: #333;
+      }
 
-    .stats .fa-database {
-      margin-right: 10px;
-      font-size: 1.5em;
-      transition: color 0.3s ease;
-      color: inherit;
-    }
+      .stats:hover {
+        background-color: #f0eaf8; /* 柔和的淡紫色 */
+        box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+        transform: scale(1.02);
+        color: #B39DDB;
+      }
 
-    .stats:hover {
-      background-color: #f0eaf8;
-      /* 使用柔和的淡紫色 */
-      box-shadow: 0 4px 6px rgba(0, 0, 0, 0.15);
-      color: #B39DDB;
-      /* 使用柔和的淡紫色 */
-    }
+      /* 上传图标样式优化 */
+      .upload-icon {
+        margin-right: 10px;
+        font-size: clamp(1.2em, 1.5vw, 1.6em);
+        transition: color 0.3s ease, transform 0.3s ease, background-color 0.3s ease;
+        color: inherit;
+        cursor: pointer;
+        border-radius: 50%;
+        padding: 8px;
+        background-color: rgba(179, 157, 219, 0.15); /* 淡紫色的背景，与整体风格一致 */
+        border: 1px solid transparent;
+      }
 
-    .stats:hover .fa-database {
-      color: #B39DDB;
-      /* 使用柔和的淡紫色 */
-    }
+      .header-content .actions {
+        display: flex;
+        align-items: center;
+      }
 
-    .header-content .actions {
-      display: flex;
-      align-items: center;
-      gap: 15px;
-    }
+      .header-content .actions i {
+        font-size: clamp(1.2em, 1.5vw, 1.6em);
+        cursor: pointer;
+        transition: color 0.3s, transform 0.3s;
+        color: #333;
+        margin: 0 8px;
+      }
 
-    .header-content .actions i {
-      font-size: 1.5em;
-      cursor: pointer;
-      transition: color 0.3s, transform 0.3s;
-      color: #333;
-    }
+      .header-content .actions i:hover {
+        color: #B39DDB; /* 使用柔和的淡紫色 */
+        transform: scale(1.1);
+      }
 
-    .header-content .actions i:hover {
-      color: #B39DDB;
-      /* 使用柔和的淡紫色 */
-      transform: scale(1.2);
-    }
+      .header-content .actions .el-dropdown-link i {
+        color: #333;
+      }
 
-    .header-content .actions .el-dropdown-link i {
-      color: #333;
-    }
+      .header-content .actions .el-dropdown-link i:hover {
+        color: #B39DDB; /* 使用柔和的淡紫色 */
+      }
 
-    .header-content .actions .el-dropdown-link i:hover {
-      color: #B39DDB;
-      /* 使用柔和的淡紫色 */
-    }
+      .header-content .actions .disabled {
+        color: #bbb;
+        pointer-events: none;
+      }
 
-    .header-content .actions .disabled {
-      color: #bbb;
-      pointer-events: none;
-    }
+      .header-content .actions .enabled {
+        color: #B39DDB; /* 使用柔和的淡紫色 */
+      }
 
-    .header-content .actions .enabled {
-      color: #B39DDB;
-      /* 使用柔和的淡紫色 */
-    }
+      .search-card .el-input__inner {
+        border-radius: 20px;
+        width: clamp(200px, 25vw, 300px);
+        height: clamp(30px, 5vh, 40px);
+        font-size: 1.2em;
+        border: none;
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+        transition: width 0.3s;
+      }
 
-    .search-card .el-input__inner {
-      border-radius: 20px;
-      width: 300px;
-      height: 40px;
-      font-size: 1.2em;
-      border: none;
-      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
-      transition: width 0.3s;
-    }
+      .search-card .el-input__inner:focus {
+        width: clamp(250px, 30vw, 400px);
+      }
 
-    .search-card .el-input__inner:focus {
-      width: 400px;
-    }
+      .main-container {
+        display: flex;
+        flex-direction: column;
+        margin-top: 20px;
+        padding: 20px;
+        min-height: calc(100vh - 80px);
+      }
 
-    .main-container {
-      display: flex;
-      flex-direction: column;
-      padding: 20px;
-      min-height: calc(100vh - 80px);
-    }
+      .content {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        gap: 20px;
+        padding: 10px;
+        flex-grow: 1;
+      }
 
-    .content {
-      display: grid;
-      grid-template-columns: repeat(5, 1fr);
-      grid-template-rows: repeat(3, 1fr);
-      gap: 20px;
-      padding: 10px;
-      flex-grow: 1;
-    }
+      .el-card {
+        width: 100%;
+        aspect-ratio: 4 / 3;
+        background: rgba(255, 255, 255, 0.6);
+        border-radius: 8px;
+        box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
+        overflow: hidden;
+        position: relative;
+        object-fit: cover;
+        transition: transform 0.3s ease;
+        border: none;
+      }
 
-    .el-card {
-      width: 100%;
-      background: rgba(255, 255, 255, 0.6);
-      border-radius: 8px;
-      box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
-      overflow: hidden;
-      position: relative;
-      transition: transform 0.3s ease;
-    }
+      .el-card:hover {
+        transform: scale(1.02);
+        cursor: pointer;
+      }
 
-    .el-card:hover {
-      transform: scale(1.05);
-    }
+      .el-image {
+        object-fit: cover;
+        transition: opacity 0.3s ease;
+      }
 
-    .el-image {
-      width: 100%;
-      height: 200px;
-      object-fit: cover;
-      transition: opacity 0.3s ease;
-    }
+      .el-image:hover {
+        opacity: 0.8;
+      }
 
-    .el-image:hover {
-      opacity: 0.8;
-    }
+      .file-info {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        padding: 10px;
+        background: rgba(0, 0, 0, 0.6);
+        color: white;
+        text-align: center;
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        width: 100%;
+        box-sizing: border-box;
+      }
 
-    .file-info {
-      padding: 10px;
-      background: rgba(0, 0, 0, 0.6);
-      color: white;
-      text-align: center;
-      position: absolute;
-      bottom: 0;
-      left: 0;
-      width: 100%;
-      box-sizing: border-box;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-    }
+      .image-overlay {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: rgba(0, 0, 0, 0.6);
+        opacity: 0;
+        transition: opacity 0.3s ease;
+      }
 
-    .image-overlay {
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      background: rgba(0, 0, 0, 0.6);
-      opacity: 0;
-      transition: opacity 0.3s ease;
-      pointer-events: none;
-    }
+      .el-card:hover .image-overlay {
+        opacity: 1;
+      }
 
-    .el-card:hover .image-overlay {
-      opacity: 1;
-    }
+      .overlay-buttons {
+        display: flex;
+        gap: 10px;
+        pointer-events: auto;
+      }
 
-    .overlay-buttons {
-      display: flex;
-      gap: 10px;
-      pointer-events: auto;
-    }
+      .pagination-container {
+        display: flex;
+        justify-content: center;
+        margin-top: 16px;
+      }
 
-    .pagination-container {
-      display: flex;
-      justify-content: center;
-      margin-top: 20px;
-      padding-bottom: 20px;
-    }
+      .collect-icon {
+        position: absolute;
+        top: -1.3px;
+        left: 10px;
+        cursor: pointer;
+        font-size: 1.5em;
+        z-index: 10;
+        transition: color 0.3s ease, transform 0.3s ease;
+      }
+      .collect-icon:hover {transform: scale(1.2);}
+      .liked {color: #FFD7E4;}
+      .not-liked {color: #b39edb80;}
 
-    .el-checkbox {
-      position: absolute;
-      top: 10px;
-      right: 10px;
-      transform: scale(1.5);
-      z-index: 10;
-    }
-  </style>
-</head>
+      .el-checkbox {
+        position: absolute;
+        top: 10px;
+        right: 10px;
+        transform: scale(1.5);
+        z-index: 10;
+      }
 
-<body>
-  <div id="app">
-    <el-container>
-      <el-header>
-        <div class="header-content">
-          <span class="title" @click="refreshDashboard">Dashboard</span>
-          <div class="search-card">
-            <el-input v-model="search" size="mini" placeholder="输入关键字搜索"></el-input>
-          </div>
-          <span class="stats">
-            <i class="fas fa-database"></i> 记录总数量: {{ Number }}
-          </span>
-          <div class="actions">
-            <el-tooltip content="排序" placement="bottom">
-              <el-dropdown @command="sort" :hide-on-click="false">
-                <span class="el-dropdown-link">
-                  <i :class="sortIcon"></i>
+      .footer {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        gap: 15px;
+        margin-top: 20px;
+        font-size: 0.9em;
+        color: #555; /* 字体颜色改为黑色 */
+      }
+
+      .footer a {
+        color: #555; /* 链接颜色 */
+        text-decoration: none;
+        transition: color 0.3s ease;
+      }
+
+      .footer a:hover {
+        color: #333; /* 悬停时的链接颜色改为黑色 */
+      }
+
+      .footer i {
+        color: #333; /* 图标颜色改为黑色 */
+      }
+
+      /* 适配移动端 */
+      @media (max-width: 768px) {
+        .content {
+          grid-template-columns: 1fr; /* 单列布局 */
+          gap: 10px;
+        }
+        .header-content{padding: 8px 12px;}
+        .stats, .actions i{margin: 0;}
+        .el-card{aspect-ratio: unset; min-height: 180px;}
+        .el-card__body{padding: 0;}
+        .search-card {display: none;}
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app">
+      <el-container>
+        <el-header>
+          <div class="header-content">
+            <span class="title" @click="refreshDashboard">Dashboard</span>
+            <div class="search-card">
+              <el-input v-model="search" size="mini" placeholder="输入关键字搜索"></el-input>
+            </div>
+            <el-tooltip content="批量上传" placement="bottom">
+                <span class="stats" @click="handleUpload">
+                  <i class="fas fa-upload upload-icon"></i>记录数: {{ Number }}
                 </span>
-                <el-dropdown-menu slot="dropdown">
-                  <el-dropdown-item command="dateDesc"
-                    :class="{ 'el-dropdown-menu__item--selected': sortOption === 'dateDesc' }">按时间倒序</el-dropdown-item>
-                  <el-dropdown-item command="nameAsc"
-                    :class="{ 'el-dropdown-menu__item--selected': sortOption === 'nameAsc' }">按名称升序</el-dropdown-item>
-                </el-dropdown-menu>
-              </el-dropdown>
             </el-tooltip>
-            <el-tooltip content="批量复制" placement="bottom">
-              <i class="fas fa-link" :class="{ disabled: selectedFiles.length === 0 }" @click="handleBatchCopy"></i>
-            </el-tooltip>
-            <el-tooltip content="批量删除" placement="bottom">
-              <i class="fas fa-trash-alt" :class="{ disabled: selectedFiles.length === 0 }"
-                @click="handleBatchDelete"></i>
-            </el-tooltip>
-            <el-tooltip content="退出登录" placement="bottom">
-              <i class="fas fa-home" @click="handleLogout"></i>
-            </el-tooltip>
+            <input type="file" ref="fileInput" style="display: none;" multiple @change="uploadFiles">
+            <div class="actions">
+              <el-tooltip content="排序" placement="bottom">
+                <el-dropdown @command="sort" :hide-on-click="false">
+                  <span class="el-dropdown-link">
+                    <i :class="sortIcon"></i>
+                  </span>
+                  <el-dropdown-menu slot="dropdown">
+                    <el-dropdown-item command="dateDesc" :class="{ 'el-dropdown-menu__item--selected': sortOption === 'dateDesc' }">按时间倒序</el-dropdown-item>
+                    <el-dropdown-item command="nameAsc" :class="{ 'el-dropdown-menu__item--selected': sortOption === 'nameAsc' }">按名称升序</el-dropdown-item>
+                  </el-dropdown-menu>
+                </el-dropdown>
+              </el-tooltip>
+              <el-tooltip content="批量复制" placement="bottom">
+                <i class="fas fa-link" :class="{ disabled: selectedFiles.length === 0 }" @click="handleBatchCopy"></i>
+              </el-tooltip>
+              <el-tooltip content="批量删除" placement="bottom">
+                <i class="fas fa-trash-alt" :class="{ disabled: selectedFiles.length === 0 }" @click="handleBatchDelete"></i>
+              </el-tooltip>
+              <el-tooltip content="退出登录" placement="bottom">
+                <i class="fas fa-home" @click="handleLogout"></i>
+              </el-tooltip>
+            </div>
           </div>
-        </div>
-      </el-header>
-      <el-main class="main-container">
-        <div class="content">
-          <template v-for="(item, index) in paginatedTableData" :key="index">
-            <el-card>
-              <el-checkbox v-model="item.selected"></el-checkbox>
-              <el-image :src="'/file/' + item.name" :preview-src-list="['/file/' + item.name]" fit="cover"
-                lazy></el-image>
-              <div class="image-overlay">
-                <div class="overlay-buttons">
-                  <el-button size="mini" type="primary" @click.stop="handleCopy(index, item.name)">复制地址</el-button>
-                  <el-button size="mini" type="danger" @click.stop="handleDelete(index, item.name)">删除</el-button>
+        </el-header>
+        <el-main class="main-container">
+          <div class="content">
+            <template v-for="(item, index) in paginatedTableData" :key="index">
+              <el-card>
+                <span class="collect-icon" @click.stop="toggleLike(index, item.name)">
+                  <i :class="item.metadata.liked ? 'fa-solid fa-bookmark liked' : 'fa-regular fa-bookmark not-liked'"></i>
+                </span>
+                <el-checkbox v-model="item.selected" :ref="'checkbox-' + index"></el-checkbox>
+                <el-image
+                  :src="'/file/' + item.name"
+                  :preview-src-list="['/file/' + item.name]"
+                  fit="cover"
+                  lazy></el-image>
+                <div class="image-overlay">
+                  <div class="overlay-buttons">
+                    <el-button size="mini" type="primary" @click.stop="handleCopy(index, item.name)">复制地址</el-button>
+                    <el-button size="mini" type="danger" @click.stop="handleDelete(index, item.name)">删除</el-button>
+                  </div>
                 </div>
-              </div>
-              <div class="file-info">{{ item.name }}</div>
-            </el-card>
-          </template>
-        </div>
-        <div class="pagination-container">
-          <el-pagination background layout="prev, pager, next" :total="filteredTableData.length" :page-size="pageSize"
-            @current-change="handlePageChange" :current-page.sync="currentPage">
-          </el-pagination>
-        </div>
-      </el-main>
-    </el-container>
-  </div>
-
+                <div class="file-info">{{ item.name }}</div>
+              </el-card>
+            </template>
+          </div>
+          <div class="pagination-container">
+            <el-pagination
+              background
+              layout="prev, pager, next"
+              :total="filteredTableData.length"
+              :page-size="pageSize"
+              @current-change="handlePageChange"
+              :current-page.sync="currentPage">
+            </el-pagination>
+          </div>
+          <el-footer class="footer">
+            <div>Powered By</div>
+            <a href="https://github.com/cf-pages/Telegraph-Image" target="_blank" rel="noopener noreferrer">
+              <div><i class="fa-brands fa-github"></i> Telegraph-Image</div>
+            </a>
+          </el-footer>
+        </el-main>
+      </el-container>
+    </div>
+  </body>
   <!-- Import Vue before Element -->
   <script src="https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.min.js"></script>
   <!-- Import JavaScript -->
@@ -311,15 +384,14 @@
     new Vue({
       el: '#app',
       data: {
+        baseURL: document.location.origin,
         Number: 0,
-        showLogoutButton: false,
         tableData: [],
         search: '',
         currentPage: 1,
         pageSize: 15,
         selectedFiles: [],
         sortOption: 'dateDesc',
-        isUploading: false
       },
       computed: {
         filteredTableData() {
@@ -332,7 +404,7 @@
           return sortedData.slice(start, end);
         },
         sortIcon() {
-          return this.sortOption === 'dateDesc' ? 'fas fa-sort-amount-down' : 'fas fa-sort-alpha-up';
+          return this.sortOption === 'dateDesc' ? 'fas  fa-sort-amount-down' : 'fas fa-sort-alpha-up';
         }
       },
       watch: {
@@ -350,6 +422,178 @@
         refreshDashboard() {
           location.reload();
         },
+        calculatePageSize() {
+          const minPageSize = 15;
+          const cardMinWidth = 240; // 卡片最小宽度
+          const cardAspectRatio = 3 / 4; // 卡片的高宽比
+          const gap = 20; // 卡片间的间隙
+
+          const contentElement = document.querySelector('.content');
+          const containerWidth = contentElement ? contentElement.clientWidth : 800;
+          const columns = Math.floor(containerWidth / (cardMinWidth + gap));
+
+          const headerElement = document.querySelector('.header-content');
+          const headerHeight = headerElement ? headerElement.offsetHeight : 60; // 使用默认值60px
+          const containerHeight = window.innerHeight - headerHeight;
+          const cardHeight = (containerWidth / columns - gap) * cardAspectRatio;
+          const rows = Math.floor(containerHeight / (cardHeight + gap));
+
+          this.pageSize = Math.max(rows * columns, minPageSize);
+        },
+        updateWindowWidth() {
+          this.windowWidth = window.innerWidth;
+          this.calculatePageSize();
+        },
+        handleUpload() {
+          this.$refs.fileInput.click();
+        },
+        uploadFiles(event) {
+          const files = event.target.files;
+          if (files.length === 0) return;
+
+          // 过滤文件类型和大小
+          const validFiles = [];
+          const invalidTypeFiles = [];
+          const oversizedFiles = [];
+
+          Array.from(files).forEach(file => {
+            const isValidType = file.type.startsWith('image/') || file.type.startsWith('video/');
+            const isValidSize = file.size <= 5 * 1024 * 1024; // 5MB
+
+            if (!isValidType) {
+              invalidTypeFiles.push(file.name);
+            } else if (!isValidSize) {
+              oversizedFiles.push(file.name);
+            } else {
+              validFiles.push(file);
+            }
+          });
+
+          // 显示错误消息
+          if (invalidTypeFiles.length > 0) {
+            this.$message.error(`以下文件类型不支持: ${invalidTypeFiles.join(', ')}`);
+          }
+          if (oversizedFiles.length > 0) {
+            this.$message.error(`以下文件超过5MB: ${oversizedFiles.join(', ')}`);
+          }
+
+          if (validFiles.length === 0) {
+            this.$message.info('没有符合条件的文件');
+            return;
+          }
+
+          console.log("ValidFiles: ", validFiles);
+          this.$confirm(`确定要上传这 ${validFiles.length} 个文件吗?`, '提示', {
+            confirmButtonText: '确定',
+            cancelButtonText: '取消',
+            type: 'warning'
+          }).then(() => {
+            // 显示上传进度
+            const loadingMessage = this.$message({
+              message: '上传中...',
+              duration: 0,
+              showClose: false,
+            });
+
+            const maxConcurrent = 3; // 最大并发数
+            let current = 0;
+            let successCount = 0;
+            let failedUploads = [];
+
+            const uploadNext = () => {
+              if (current >= validFiles.length) {
+                // 检查是否所有文件都已处理
+                if (successCount + failedUploads.length === validFiles.length) {
+                  loadingMessage.close();
+                  if (successCount > 0) {
+                    this.$message.success(`成功上传 ${successCount} 个文件!`);
+                  }
+                  if (failedUploads.length > 0) {
+                    this.$message.error(`上传失败: ${failedUploads.join(', ')}`);
+                  }
+                  // 刷新文件列表
+                  this.refreshFileList();
+                }
+                return;
+              }
+
+              const file = validFiles[current];
+              current++;
+
+              const formData = new FormData();
+              formData.append('file', file);
+
+              fetch(this.baseURL + '/upload', {
+                method: 'POST',
+                body: formData,
+                credentials: 'include'
+              }).then(response => {
+                if (!response.ok) {
+                  throw new Error(`上传失败: ${file.name}`);
+                }
+                return response.json();
+              }).then(result => {
+                if (Array.isArray(result) && result.length > 0 && result[0].error) {
+                  // 响应内容中包含错误
+                  throw new Error(result[0].error || `上传失败: ${file.name}`);
+                }
+
+                // 确保 result[0].src 存在
+                if (!result[0].src) {
+                  throw new Error(`上传成功但未返回文件路径: ${file.name}`);
+                }
+
+                successCount++;
+
+                // 处理成功上传的文件
+                const previewUrl = `${this.baseURL}${result[0].src}`;
+                if (result[0].src) {
+                  fetch(previewUrl, { method: 'GET', credentials: 'include' })
+                    .then(response => {
+                      if (!response.ok) {
+                        console.error(`无法获取文件: ${previewUrl}`);
+                      } else {
+                        this.tableData.unshift({
+                          name: result[0].src.replace(/^\/file\//, ''),
+                          selected: false,
+                          metadata: { TimeStamp: Date.now() }
+                        });
+                      }
+                    }).catch(error => {
+                      console.error(`获取文件时出错: ${previewUrl}`, error);
+                    });
+                }
+              }).catch(error => {
+                failedUploads.push(file.name); // 记录失败的文件名称
+                console.error(error.message);
+              }).finally(() => {
+                uploadNext(); // 继续上传下一个文件
+              });
+            };
+
+            // 启动初始的并发上传任务
+            for (let i = 0; i < maxConcurrent && i < validFiles.length; i++) {
+              uploadNext();
+            }
+
+          }).catch(() => {
+            this.$message.info('已取消上传');
+          });
+
+          // 清空文件输入，以便可以重复选择相同的文件
+          event.target.value = '';
+        },
+        refreshFileList() {
+          // 重新获取文件列表
+          fetch("./api/manage/list", { method: 'GET', credentials: 'include' })
+            .then(response => response.json())
+            .then(result => {
+              this.tableData = result.map(file => ({ ...file, selected: false }));
+              this.updateStats();
+              this.sortData(this.tableData);
+            })
+            .catch(() => this.$message.error('刷新文件列表失败，请检查网络连接'));
+        },
         handleDelete(index, key) {
           this.$confirm('此操作将永久删除该文件, 是否继续?', '提示', {
             confirmButtonText: '确定',
@@ -360,7 +604,7 @@
               .then(response => response.ok ? this.tableData.splice(index, 1) : Promise.reject())
               .then(() => {
                 this.updateStats();
-                this.$message.success('删除成功!');
+                this.$message.success('删除成功！');
               })
               .catch(() => this.$message.error('删除失败，请检查网络连接'));
           }).catch(() => this.$message.info('已取消删除'));
@@ -411,12 +655,53 @@
           window.location.href = '/';
         },
         handleCopy(index, key) {
-          const text = `${document.location.origin}/file/${key}`;
+          const text = `${this.baseURL}/file/${key}`;
           navigator.clipboard ? navigator.clipboard.writeText(text).then(() => this.$message.success('复制文件链接成功~')) :
             this.copyToClipboardFallback(text);
         },
         handlePageChange(page) {
           this.currentPage = page;
+        },
+        // 处理收藏事件
+        toggleLike(index, key) {
+          console.log(`Toggling like for image: ${key}`);
+
+          // 乐观更新收藏状态
+          if (this.tableData[index].metadata.liked === undefined) {
+            this.tableData[index].metadata.liked = false;
+          }
+          this.tableData[index].metadata.liked = !this.tableData[index].metadata.liked;
+
+          // 发送请求更新服务器数据
+          var requestOptions = {
+            method: 'GET',
+            redirect: 'follow',
+            credentials: 'include'
+          };
+
+          fetch(`./api/manage/toggleLike/${key}`, requestOptions)
+            .then(response => response.json())
+            .then(result => {
+              if (!result.success) {
+                // 如果服务器更新失败，将状态还原
+                this.tableData[index].metadata.liked = !this.tableData[index].metadata.liked;
+                this.$message({
+                  message: '更新收藏状态失败，请稍后重试',
+                  type: 'error'
+                });
+              } else {
+                this.$message.success('更新收藏状态成功');
+              }
+            })
+            .catch(error => {
+              console.error("An error occurred while synchronizing data with the server", error);
+              // 如果服务器响应错误，将状态还原
+              this.tableData[index].metadata.liked = !this.tableData[index].metadata.liked;
+              this.$message({
+                message: '同步服务器失败，请检查网络连接',
+                type: 'error'
+              });
+            });
         },
         updateStats() {
           this.Number = this.tableData.length;
@@ -430,6 +715,8 @@
         }
       },
       mounted() {
+        window.addEventListener('resize', this.calculatePageSize);
+        this.updateWindowWidth();
         fetch("./api/manage/check", { method: 'GET', credentials: 'include' })
           .then(response => response.text())
           .then(result => {
@@ -446,7 +733,15 @@
         fetch("./api/manage/list", { method: 'GET', credentials: 'include' })
           .then(response => response.json())
           .then(result => {
-            this.tableData = result.map(file => ({ ...file, selected: false }));
+            console.log("result: ", result);
+            this.tableData = result.map(file => ({
+              ...file,
+              selected: false,
+              metadata: {
+                ...file.metadata,
+                liked: file.metadata.liked !== undefined ? file.metadata.liked : false
+              }
+            }));
             this.updateStats();
             const savedSortOption = localStorage.getItem('sortOption');
             if (savedSortOption) {
@@ -455,9 +750,10 @@
             this.sortData(this.tableData);
           })
           .catch(() => this.$message.error('同步数据时出错，请检查网络连接'));
+      },
+      beforeDestroy() {
+        window.removeEventListener('resize', this.calculatePageSize);
       }
     });
   </script>
-</body>
-
-</html>
+  </html>

--- a/admin.html
+++ b/admin.html
@@ -1,64 +1,61 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="UTF-8">
   <!-- import CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/element-ui@2.15.3/lib/theme-chalk/index.css" integrity="sha256-ghr1zmXTODLKl1HULQd6fq1MIe7m3FJiNTOCT8sddLM=" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/element-ui@2.15.3/lib/theme-chalk/index.css"
+    integrity="sha256-ghr1zmXTODLKl1HULQd6fq1MIe7m3FJiNTOCT8sddLM=" crossorigin="anonymous">
   <style>
     .el-image__inner.el-image__inner {
       width: 100%;
       height: 90px;
     }
+
     .el-image {
       text-align: center;
     }
+
     .el-button+.el-button {
       margin: 0;
     }
   </style>
   <script src="https://js.sentry-cdn.com/219f636ac7bde5edab2c3e16885cb535.min.js" crossorigin="anonymous"></script>
 </head>
+
 <body>
   <div id="app">
     <el-container>
-        <el-header>
-         <div style="
+      <el-header>
+        <div style="
          margin: auto;
          line-height: 60px;
          font-size: xx-large;
          position: relative;
      ">Dashboard
-     
 
-     <span style="
+
+          <span style="
      position: absolute;
      right: 0px;
-      " v-if="showLogoutButton">
-      <a href="./admin-imgtc.html">
-      <el-button
-      size="mini"
-      type="warning"
-      >网格视图</el-button>
-      </a>
-      <a href="./admin-waterfall.html">
-      <el-button
-      size="mini"
-      type="primary"
-      >瀑布流</el-button>
-      </a>
-      <el-button
-                    size="mini"
-                    type="info"
-                    @click="handleLogout()">退出登录</el-button></span></div> 
-        </el-header>
-        <el-main><el-row :gutter="12">
-            <el-col :span="24">
-              <el-card shadow="always">
-                记录总数量:
-                {{ Number }} 
-              </el-card>
-            </el-col>
-            <!--<el-col :span="8">
+      ">
+            <a href="./admin-imgtc.html">
+              <el-button size="mini" type="warning">网格视图</el-button>
+            </a>
+            <a href="./admin-waterfall.html">
+              <el-button size="mini" type="primary">瀑布流</el-button>
+            </a>
+            <el-button v-if="showLogoutButton" size="mini" type="info" @click="handleLogout()">退出登录</el-button></span>
+        </div>
+      </el-header>
+      <el-main><el-row :gutter="12">
+          <el-col :span="24">
+            <el-card shadow="always">
+              记录总数量:
+              {{ Number }}
+            </el-card>
+          </el-col>
+          <!--<el-col :span="8">
               <el-card shadow="hover">
                 <el-tooltip class="item" effect="dark" content="白名单数量" placement="top-start">
                    
@@ -74,39 +71,24 @@
               黑名单数量：{{ BlackList }}
               </el-card>
             </el-col>-->
-          </el-row>
-          <template>
-            <el-table
-              :data="tableData.filter(data => !search || data.name.toLowerCase().includes(search.toLowerCase()))"
-              style="width: 100%">
-              <el-table-column
-                label="name"
-                prop="name">
-              </el-table-column>
-              <el-table-column
-                label="preview"
-                prop="preview"
-                align="center">
-                <template slot-scope="scope">
-                  <video v-if="scope.row.name.indexOf('.mp4')>0" style="width: 100%; height: 180px;" controls>
-                    <source :src="'/file/'+scope.row.name" type="video/mp4">
-                  </video>
-                  <el-image
-                    v-else
-                    style="width: 100%; height: 100%;"
-                    :src="'/file/'+scope.row.name"
-                    :zoom-rate="1.2"
-                    :preview-src-list="['/file/'+scope.row.name]"
-                    fit="cover"
-                    lazy
-                  />
+        </el-row>
+        <template>
+          <el-table :data="tableData.filter(data => !search || data.name.toLowerCase().includes(search.toLowerCase()))"
+            style="width: 100%">
+            <el-table-column label="name" prop="name">
+            </el-table-column>
+            <el-table-column label="preview" prop="preview" align="center">
+              <template slot-scope="scope">
+                <video v-if="scope.row.name.indexOf('.mp4')>0" style="width: 100%; height: 180px;" controls>
+                  <source :src="'/file/'+scope.row.name" type="video/mp4">
+                </video>
+                <el-image v-else style="width: 100%; height: 100%;" :src="'/file/'+scope.row.name" :zoom-rate="1.2"
+                  :preview-src-list="['/file/'+scope.row.name]" fit="cover" lazy />
 
-                </template>
-              </el-table-column>
-              <el-table-column
-                label="data"
-                prop="data">
-                <template slot-scope="scope">
+              </template>
+            </el-table-column>
+            <el-table-column label="data" prop="data">
+              <template slot-scope="scope">
                 <el-popover trigger="hover" placement="top">
                   <p>{{ scope.row.metadata }}</p>
                   <div slot="reference" class="name-wrapper">
@@ -114,156 +96,144 @@
                   </div>
                 </el-popover>
               </template>
-              </el-table-column>
-              <el-table-column
-              align="right">
-                <template slot="header" slot-scope="scope">
-                  <el-input
-                    v-model="search"
-                    size="mini"
-                    placeholder="输入关键字搜索"/>
-                </template>
-                <template slot-scope="scope">
-                  <el-button
-                    size="mini"
-                    type="primary"
-                    @click="handleCopy(scope.$index,scope.row.name)">复制地址</el-button>
-                  <el-button
-                    size="mini"
-                    type="primary"
-                    @click="handleWhite(scope.$index,scope.row.name)">白名单</el-button>
-                  <el-button
-                    size="mini"
-                    type="info"
-                    @click="handleBlock(scope.$index,scope.row.name)">黑名单</el-button>
-                    <el-button
-                    size="mini"
-                    type="danger"
-                    @click="handleDelete(scope.$index,scope.row.name)">删除</el-button>
-                </template>
-              </el-table-column>
-            </el-table>
-          </template>
-        </el-main>
+            </el-table-column>
+            <el-table-column align="right">
+              <template slot="header" slot-scope="scope">
+                <el-input v-model="search" size="mini" placeholder="输入关键字搜索" />
+              </template>
+              <template slot-scope="scope">
+                <el-button size="mini" type="primary" @click="handleCopy(scope.$index,scope.row.name)">复制地址</el-button>
+                <el-button size="mini" type="primary" @click="handleWhite(scope.$index,scope.row.name)">白名单</el-button>
+                <el-button size="mini" type="info" @click="handleBlock(scope.$index,scope.row.name)">黑名单</el-button>
+                <el-button size="mini" type="danger" @click="handleDelete(scope.$index,scope.row.name)">删除</el-button>
+              </template>
+            </el-table-column>
+          </el-table>
+        </template>
+      </el-main>
     </el-container>
   </div>
 </body>
-  <!-- import Vue before Element -->
-  <script src="https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.min.js" integrity="sha256-kXTEJcRFN330VirZFl6gj9+UM6gIKW195fYZeR3xDhc=" crossorigin="anonymous"></script>
-  <!-- import JavaScript -->
-  <script src="https://cdn.jsdelivr.net/npm/element-ui@2.15.3/lib/index.js" integrity="sha256-OFVFYfqhQ9nDnKh+NfIsefpy/fnjTwkK909ZYgo45nw=" crossorigin="anonymous"></script>
-  <script>
-    var app=new Vue({
-      el: '#app',
-      data: {
-        Number:0,
-        WhiteList:0,
-        BlackList:0,
-        showLogoutButton:false,
-        tableData: [],
-        dialogFormVisible: false,
-        formLabelWidth: '120px',
-        form: {
-          name: '',
-          id: ''
-        },
-        search: '',
-        password:'123456'
+<!-- import Vue before Element -->
+<script src="https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.min.js"
+  integrity="sha256-kXTEJcRFN330VirZFl6gj9+UM6gIKW195fYZeR3xDhc=" crossorigin="anonymous"></script>
+<!-- import JavaScript -->
+<script src="https://cdn.jsdelivr.net/npm/element-ui@2.15.3/lib/index.js"
+  integrity="sha256-OFVFYfqhQ9nDnKh+NfIsefpy/fnjTwkK909ZYgo45nw=" crossorigin="anonymous"></script>
+<script>
+  var app = new Vue({
+    el: '#app',
+    data: {
+      Number: 0,
+      WhiteList: 0,
+      BlackList: 0,
+      showLogoutButton: false,
+      tableData: [],
+      dialogFormVisible: false,
+      formLabelWidth: '120px',
+      form: {
+        name: '',
+        id: ''
       },
-      methods: {
-      handleBlock(index,key) {
+      search: '',
+      password: '123456'
+    },
+    methods: {
+      handleBlock(index, key) {
         console.log(key);
         if (confirm("确认加入黑名单吗?")) {
-        console.log("Yes")
-        var requestOptions = {
-          method: 'GET',
-          redirect: 'follow',
-          //include authorization credientials
-          credentials: 'include'
-        };
+          console.log("Yes")
+          var requestOptions = {
+            method: 'GET',
+            redirect: 'follow',
+            //include authorization credientials
+            credentials: 'include'
+          };
 
-        fetch("./api/manage/block/"+key, requestOptions)
-          .then(response => response.text())
-          .then(result => {console.log(result);
-            this.tableData[index].metadata=result;})
-          .catch(error =>  {alert("An error occurred while synchronizing data with the server, please check the network connection");console.log('error', error)});
-        
+          fetch("./api/manage/block/" + key, requestOptions)
+            .then(response => response.text())
+            .then(result => {
+              console.log(result);
+              this.tableData[index].metadata = result;
+            })
+            .catch(error => { alert("An error occurred while synchronizing data with the server, please check the network connection"); console.log('error', error) });
+
         } else {
-        console.log("No")
-      }
-    },
-    handleDelete(index,key) {
+          console.log("No")
+        }
+      },
+      handleDelete(index, key) {
         console.log(key);
         if (confirm("确认删除该条记录吗?")) {
-        console.log("Yes")
-        var requestOptions = {
-          method: 'GET',
-          redirect: 'follow',
-          //include authorization credientials
-          credentials: 'include'
-        };
+          console.log("Yes")
+          var requestOptions = {
+            method: 'GET',
+            redirect: 'follow',
+            //include authorization credientials
+            credentials: 'include'
+          };
 
-        fetch("./api/manage/delete/"+key, requestOptions)
-          .then(response => response.text())
-          .then(result => {console.log(result);this.tableData.remove(index);})
-          .catch(error =>  {alert("An error occurred while synchronizing data with the server, please check the network connection");console.log('error', error)});
-        
+          fetch("./api/manage/delete/" + key, requestOptions)
+            .then(response => response.text())
+            .then(result => { console.log(result); this.tableData.remove(index); })
+            .catch(error => { alert("An error occurred while synchronizing data with the server, please check the network connection"); console.log('error', error) });
+
         } else {
-        console.log("No")
-      }
-    },
-    handleWhite(index,key) {
-      console.log(key);
-      if (confirm("确认加入白名单吗?")) {
-      console.log("Yes")
-      var requestOptions = {
-        method: 'GET',
-        redirect: 'follow',
-        //include authorization credientials
-        credentials: 'include'
-      };
-      fetch("./api/manage/white/"+key, requestOptions)
-          .then(response => response.text())
-          .then(result => {console.log(result);this.tableData[index].metadata=result;})
-          .catch(error =>  {alert("An error occurred while synchronizing data with the server, please check the network connection");console.log('error', error)});
-        
+          console.log("No")
+        }
+      },
+      handleWhite(index, key) {
+        console.log(key);
+        if (confirm("确认加入白名单吗?")) {
+          console.log("Yes")
+          var requestOptions = {
+            method: 'GET',
+            redirect: 'follow',
+            //include authorization credientials
+            credentials: 'include'
+          };
+          fetch("./api/manage/white/" + key, requestOptions)
+            .then(response => response.text())
+            .then(result => { console.log(result); this.tableData[index].metadata = result; })
+            .catch(error => { alert("An error occurred while synchronizing data with the server, please check the network connection"); console.log('error', error) });
+
         } else {
-        console.log("No")
-      }
+          console.log("No")
+        }
 
       },
-      handleLogout(){
-        window.location.href="./api/manage/logout";
+      handleLogout() {
+        window.location.href = "./api/manage/logout";
       },
       handleCopy(index, key) {
         const text = `${document.location.origin}/file/${key}`;
         if (navigator.clipboard) {
-            // clipboard api 复制
-            navigator.clipboard.writeText(text);
+          // clipboard api 复制
+          navigator.clipboard.writeText(text);
         } else {
-            const textarea = document.createElement('textarea');
-            document.body.appendChild(textarea);
-            // 隐藏此输入框
-            textarea.style.position = 'fixed';
-            textarea.style.clip = 'rect(0 0 0 0)';
-            textarea.style.top = '10px';
-            // 赋值
-            textarea.value = text;
-            // 选中
-            textarea.select();
-            // 复制
-            document.execCommand('copy', true);
-            // 移除输入框
-            document.body.removeChild(textarea);
+          const textarea = document.createElement('textarea');
+          document.body.appendChild(textarea);
+          // 隐藏此输入框
+          textarea.style.position = 'fixed';
+          textarea.style.clip = 'rect(0 0 0 0)';
+          textarea.style.top = '10px';
+          // 赋值
+          textarea.value = text;
+          // 选中
+          textarea.select();
+          // 复制
+          document.execCommand('copy', true);
+          // 移除输入框
+          document.body.removeChild(textarea);
         }
         this.$message({
-            message: '复制文件链接成功~',
-            type: 'success'
+          message: '复制文件链接成功~',
+          type: 'success'
         });
       },
     },
-      
-    mounted () {
+
+    mounted() {
       //check if the user is logged in
       //read the basic auth credientials from the browser
       var requestOptions = {
@@ -274,68 +244,70 @@
       };
       fetch("./api/manage/check", requestOptions)
         .then(response => response.text())
-        .then(result => {console.log(result);
-          if(result=="true"){
-            this.showLogoutButton=true;
-          }else if(result=="Not using basic auth."){
-            
+        .then(result => {
+          console.log(result);
+          if (result == "true") {
+            this.showLogoutButton = true;
+          } else if (result == "Not using basic auth.") {
+
           }
-          else{
-            window.location.href="./api/manage/login";
+          else {
+            window.location.href = "./api/manage/login";
           }
         })
-        .catch(error =>  {alert("An error occurred while synchronizing data with the server, please check the network connection");console.log('error', error)});
+        .catch(error => { alert("An error occurred while synchronizing data with the server, please check the network connection"); console.log('error', error) });
 
 
 
-      Array.prototype.remove = function(from, to) {
+      Array.prototype.remove = function (from, to) {
         var rest = this.slice((to || from) + 1 || this.length);
         this.length = from < 0 ? this.length + from : from;
         return this.push.apply(this, rest);
       };
       var requestOptions = {
-  method: 'GET',
-  redirect: 'follow',
-  //include authorization credientials
-  credentials: 'include'
-  
-};
+        method: 'GET',
+        redirect: 'follow',
+        //include authorization credientials
+        credentials: 'include'
+
+      };
 
 
-fetch("./api/manage/list", requestOptions)
-  //判断是否需要登录
-  .then(response => {
-    if(response.status==401){
-      alert("请先登录");
-      window.location.href="./api/manage/login";
-    }
-    else{
-      return response;
+      fetch("./api/manage/list", requestOptions)
+        //判断是否需要登录
+        .then(response => {
+          if (response.status == 401) {
+            alert("请先登录");
+            window.location.href = "./api/manage/login";
+          }
+          else {
+            return response;
+          }
+        })
+        .then(response => response.text())
+        .then(result => { this.tableData = JSON.parse(result); console.log(result); this.Number = this.tableData.length })
+        .catch(error => { alert("An error occurred while synchronizing data with the server, please check the network connection"); console.log('error', error) });
+
     }
   })
-  .then(response => response.text()) 
-  .then(result => {this.tableData=JSON.parse(result);console.log(result);this.Number=this.tableData.length})
-  .catch(error => {alert("An error occurred while synchronizing data with the server, please check the network connection");console.log('error', error)});
 
-    }
-    })
-    
-  </script><!-- Hotjar Tracking Code -->
+</script><!-- Hotjar Tracking Code -->
 <script>
-    (function(h,o,t,j,a,r){
-        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-        h._hjSettings={hjid:2531461,hjsv:6};
-        a=o.getElementsByTagName('head')[0];
-        r=o.createElement('script');r.async=1;
-        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-        a.appendChild(r);
-    })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+    (function (h, o, t, j, a, r) {
+      h.hj = h.hj || function () { (h.hj.q = h.hj.q || []).push(arguments) };
+      h._hjSettings = { hjid: 2531461, hjsv: 6 };
+      a = o.getElementsByTagName('head')[0];
+      r = o.createElement('script'); r.async = 1;
+      r.src = t + h._hjSettings.hjid + j + h._hjSettings.hjsv;
+      a.appendChild(r);
+    })(window, document, 'https://static.hotjar.com/c/hotjar-', '.js?sv=');
 </script>
 <script type="text/javascript">
-  (function(c,l,a,r,i,t,y){
-      c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-      t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-      y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+  (function (c, l, a, r, i, t, y) {
+    c[a] = c[a] || function () { (c[a].q = c[a].q || []).push(arguments) };
+    t = l.createElement(r); t.async = 1; t.src = "https://www.clarity.ms/tag/" + i;
+    y = l.getElementsByTagName(r)[0]; y.parentNode.insertBefore(t, y);
   })(window, document, "clarity", "script", "7t5ai7agat");
 </script>
+
 </html>

--- a/functions/api/manage/list.js
+++ b/functions/api/manage/list.js
@@ -1,30 +1,30 @@
 export async function onRequest(context) {
-    // Contents of context object
-    const {
-      request, // same as existing Worker API
-      env, // same as existing Worker API
-      params, // if filename includes [id] or [[path]]
-      waitUntil, // same as ctx.waitUntil in existing Worker API
-      next, // used for middleware or to fetch assets
-      data, // arbitrary space for passing data between middlewares
-    } = context;
-    console.log(env)
-    const value = await env.img_url.list();
+  // Contents of context object
+  const {
+    request, // same as existing Worker API
+    env, // same as existing Worker API
+    params, // if filename includes [id] or [[path]]
+    waitUntil, // same as ctx.waitUntil in existing Worker API
+    next, // used for middleware or to fetch assets
+    data, // arbitrary space for passing data between middlewares
+  } = context;
+  console.log(env)
+  const value = await env.img_url.list();
 
-    console.log(value)
-    //let res=[]
-    //for (let i in value.keys){
-      //add to res
-      //"metadata":{"TimeStamp":19876541,"ListType":"None","rating_label":"None"}
-      //let tmp = {
-      //  name: value.keys[i].name,
-      //  TimeStamp: value.keys[i].metadata.TimeStamp,
-      //  ListType: value.keys[i].metadata.ListType,
-      //  rating_label: value.keys[i].metadata.rating_label,
-      //}
-      //res.push(tmp)
+  console.log(value)
+  //let res=[]
+  //for (let i in value.keys){
+    //add to res
+    //"metadata":{"TimeStamp":19876541,"ListType":"None","rating_label":"None"}
+    //let tmp = {
+    //  name: value.keys[i].name,
+    //  TimeStamp: value.keys[i].metadata.TimeStamp,
+    //  ListType: value.keys[i].metadata.ListType,
+    //  rating_label: value.keys[i].metadata.rating_label,
     //}
-    const info = JSON.stringify(value.keys);
-    return new Response(info);
+    //res.push(tmp)
+  //}
+  const info = JSON.stringify(value.keys);
+  return new Response(info);
 
-  }
+}

--- a/functions/api/manage/toggleLike/[id].js
+++ b/functions/api/manage/toggleLike/[id].js
@@ -8,7 +8,7 @@ export async function onRequest(context) {
     console.log("Current metadata:", value);
 
     // 如果记录不存在
-    if (!value.metadata) return new Response("Image metadata not found", { status: 404 });
+    if (!value.metadata) return new Response(`Image metadata not found for ID: ${params.id}`, { status: 404 });
 
     // 切换 liked 状态并更新
     value.metadata.liked = !value.metadata.liked;

--- a/functions/api/manage/toggleLike/[id].js
+++ b/functions/api/manage/toggleLike/[id].js
@@ -1,0 +1,22 @@
+export async function onRequest(context) {
+    const { params, env } = context;
+
+    console.log("Request ID:", params.id);
+
+    // 获取元数据
+    const value = await env.img_url.getWithMetadata(params.id);
+    console.log("Current metadata:", value);
+
+    // 如果记录不存在
+    if (!value.metadata) return new Response("Image metadata not found", { status: 404 });
+
+    // 切换 liked 状态并更新
+    value.metadata.liked = !value.metadata.liked;
+    await env.img_url.put(params.id, "", { metadata: value.metadata });
+
+    console.log("Updated metadata:", value.metadata);
+
+    return new Response(JSON.stringify({ success: true, liked: value.metadata.liked }), {
+        headers: { 'Content-Type': 'application/json' },
+    });
+}

--- a/functions/upload.js
+++ b/functions/upload.js
@@ -1,29 +1,93 @@
 import { errorHandling, telemetryData } from "./utils/middleware";
-export async function onRequestPost(context) {  // Contents of context object  
-    const {
-        request, // same as existing Worker API    
-        env, // same as existing Worker API    
-        params, // if filename includes [id] or [[path]]   
-        waitUntil, // same as ctx.waitUntil in existing Worker API    
-        next, // used for middleware or to fetch assets    
-        data, // arbitrary space for passing data between middlewares 
-    } = context;
-    const clonedRequest = request.clone();
-    await errorHandling(context);
-    telemetryData(context);
-    const url = new URL(clonedRequest.url);
-    url.searchParams.append('source', 'bugtracker');
-    const response = await fetch('https://telegra.ph/' + url.pathname + url.search, {
-        method: clonedRequest.method,
-        headers: clonedRequest.headers,
-        body: clonedRequest.body,
-    });
-    const originalBody = await response.json();
-    const wrappedBody = [originalBody];
-    const modifiedResponse = new Response(JSON.stringify(wrappedBody), {
-        status: response.status,
-        statusText: response.statusText,
-        headers: response.headers
-    });
-    return modifiedResponse;
+
+export async function onRequestPost(context) {
+    const { request, env } = context;
+
+    try {
+
+        const clonedRequest = request.clone();
+        const formData = await clonedRequest.formData();
+
+        await errorHandling(context);
+        telemetryData(context);
+        
+        const uploadFile = formData.get('file');
+        if (!uploadFile) {
+            throw new Error('No file uploaded');
+        }
+
+        const fileName = uploadFile.name;
+        const fileExtension = fileName.split('.').pop().toLowerCase();
+
+        const telegramFormData = new FormData();
+        telegramFormData.append("chat_id", env.TG_Chat_ID);
+
+        // 根据文件类型选择合适的上传方式
+        let apiEndpoint;
+        if (uploadFile.type.startsWith('image/')) {
+            telegramFormData.append("photo", uploadFile);
+            apiEndpoint = 'sendPhoto';
+        } else {
+            telegramFormData.append("document", uploadFile);
+            apiEndpoint = 'sendDocument';
+        }
+
+        const apiUrl = `https://api.telegram.org/bot${env.TG_Bot_Token}/${apiEndpoint}`;
+        console.log('Sending request to:', apiUrl);
+
+        const response = await fetch(
+            apiUrl,
+            {
+                method: "POST",
+                body: telegramFormData
+            }
+        );
+
+        console.log('Response status:', response.status);
+
+        const responseData = await response.json();
+
+        if (!response.ok) {
+            console.error('Error response from Telegram API:', responseData);
+            throw new Error(responseData.description || 'Upload to Telegram failed');
+        }
+
+        const fileId = getFileId(responseData);
+
+        if (!fileId) {
+            throw new Error('Failed to get file ID');
+        }
+
+        return new Response(
+            JSON.stringify([{ 'src': `/file/${fileId}.${fileExtension}` }]),
+            {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' }
+            }
+        );
+    } catch (error) {
+        console.error('Upload error:', error);
+        return new Response(
+            JSON.stringify({ error: error.message }),
+            {
+                status: 500,
+                headers: { 'Content-Type': 'application/json' }
+            }
+        );
+    }
+}
+
+function getFileId(response) {
+    if (!response.ok || !response.result) return null;
+
+    const result = response.result;
+    if (result.photo) {
+        return result.photo.reduce((prev, current) =>
+            (prev.file_size > current.file_size) ? prev : current
+        ).file_id;
+    }
+    if (result.document) return result.document.file_id;
+    if (result.video) return result.video.file_id;
+
+    return null;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "ci-test": "concurrently --kill-others \"npm start\" \"wait-on http://localhost:8080 && mocha\"",
+    "ci-test": "concurrently --kill-others --success first \"npm start\" \"wait-on http://localhost:8080 && mocha --exit\"",
     "test": "mocha",
     "start": "npx wrangler pages dev ./ --kv \"img_url\" --port 8080 --binding BASIC_USER=admin --binding BASIC_PASS=123 --persist-to ./data"
   },


### PR DESCRIPTION
只修改了`admin-imgtc.html`，具体更新内容：

#### **批量上传**

- 将批量上传功能整合至`stats`组件，调用`/upload` API，支持一次上传多个文件，最大并发数为3。目前测试上传11张图片成功。
- 上传成功后**自动通过GET请求**更新卡片列表，用户**无需再手动访问图片链接**即可更新后台数据。
- 上传前会检查**文件类型和大小**（不超过5MB的图片或视频），上传失败时将弹出提示框**显示失败的文件**。

#### 移动端适配

- 屏幕宽度小于768px时改为**单列显示，隐藏搜索栏**
- 每页显示**15张图片**（设置的单页最少图片数）

#### 样式改进

- 调整组件大小和位置，新增带GitHub仓库链接的**页脚**

- 改进分页逻辑，用户可**通过缩放改变单页图片数**，以快速浏览更多图片
  

---

另外，想请教一下**增加收藏夹功能**是否可行。

（`list.js`请忽略，commit较多是由于频繁部署调试）

示例图：
![image](https://github.com/user-attachments/assets/206951e9-8225-42cd-8d1f-448964b0a54b)
![Screenshot_2024-10-22-10-51-33-316_com.mmbox.xbrowser.pro.jpg](https://github.com/user-attachments/assets/a083fb3c-cce7-47f6-abfc-0f8546fcf511)

