### PR TITLE
Refactor Pages functions and expand tests

### DIFF
--- a/functions/api/_middleware.js
+++ b/functions/api/_middleware.js
@@ -1,3 +1,3 @@
-import { errorHandling, telemetryData } from '../utils/middleware';
+import { errorHandling, telemetryData } from '../utils/middleware.js';
 
 export const onRequest = [errorHandling, telemetryData];

--- a/functions/api/manage/_middleware.js
+++ b/functions/api/manage/_middleware.js
@@ -1,3 +1,11 @@
+import {
+    basicAuthentication,
+    basicAuthChallengeResponse,
+    dashboardDisabledResponse,
+    unauthorizedResponse,
+} from "../../utils/auth.js";
+import { isEmptyBinding } from "../../utils/http.js";
+
 async function errorHandling(context) {
     try {
       return await context.next();
@@ -6,101 +14,29 @@ async function errorHandling(context) {
     }
   }
 
-  function basicAuthentication(request) {
-    const Authorization = request.headers.get('Authorization');
-  
-    const [scheme, encoded] = Authorization.split(' ');
-  
-    // The Authorization header must start with Basic, followed by a space.
-    if (!encoded || scheme !== 'Basic') {
-      throw new BadRequestException('Malformed authorization header.');
-    }
-  
-    // Decodes the base64 value and performs unicode normalization.
-    // @see https://datatracker.ietf.org/doc/html/rfc7613#section-3.3.2 (and #section-4.2.2)
-    // @see https://dev.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/normalize
-    const buffer = Uint8Array.from(atob(encoded), character => character.charCodeAt(0));
-    const decoded = new TextDecoder().decode(buffer).normalize();
-  
-    // The username & password are split by the first colon.
-    //=> example: "username:password"
-    const index = decoded.indexOf(':');
-  
-    // The user & password are split by the first colon and MUST NOT contain control characters.
-    // @see https://tools.ietf.org/html/rfc5234#appendix-B.1 (=> "CTL = %x00-1F / %x7F")
-    if (index === -1 || /[\0-\x1F\x7F]/.test(decoded)) {
-      throw new BadRequestException('Invalid authorization value.');
-    }
-  
-    return {
-      user: decoded.substring(0, index),
-      pass: decoded.substring(index + 1),
-    };
-  }
-  
-  function UnauthorizedException(reason) {
-    return new Response(reason, {
-        status: 401,
-        statusText: 'Unauthorized',
-        headers: {
-          'Content-Type': 'text/plain;charset=UTF-8',
-          // Disables caching by default.
-          'Cache-Control': 'no-store',
-          // Returns the "Content-Length" header for HTTP HEAD requests.
-          'Content-Length': reason.length,
-        },
-      });
-  }
-  
-  function BadRequestException(reason) {
-    return new Response(reason, {
-        status: 400,
-        statusText: 'Bad Request',
-        headers: {
-          'Content-Type': 'text/plain;charset=UTF-8',
-          // Disables caching by default.
-          'Cache-Control': 'no-store',
-          // Returns the "Content-Length" header for HTTP HEAD requests.
-          'Content-Length': reason.length,
-        },
-      });
-  }
-  
-  
   function authentication(context) {
-    //context.env.BASIC_USER="admin"
-    //context.env.BASIC_PASS="admin"
-    //check if the env variables Disable_Dashboard are set
-    if (typeof context.env.img_url == "undefined" || context.env.img_url == null || context.env.img_url == "") {
-        return new Response('Dashboard is disabled. Please bind a KV namespace to use this feature.', { status: 200 });
+    if (isEmptyBinding(context.env.img_url)) {
+        return dashboardDisabledResponse();
     }
 
-    console.log(context.env.BASIC_USER)
-    if(typeof context.env.BASIC_USER == "undefined" || context.env.BASIC_USER == null || context.env.BASIC_USER == ""){
+    if (isEmptyBinding(context.env.BASIC_USER)) {
         return context.next();
-    }else{
-        if (context.request.headers.has('Authorization')) {
-            // Throws exception when authorization fails.
-            const { user, pass } = basicAuthentication(context.request);
-            
-                          
-                if (context.env.BASIC_USER !== user || context.env.BASIC_PASS !== pass) {
-                    return UnauthorizedException('Invalid credentials.');
-                }else{
-                    return context.next();
-                }
-            
-        } else {
-            return new Response('You need to login.', {
-                status: 401,
-                headers: {
-                // Prompts the user for credentials.
-                'WWW-Authenticate': 'Basic realm="my scope", charset="UTF-8"',
-                },
-            });
-        }
-    }  
-    
+    }
+
+    if (!context.request.headers.has('Authorization')) {
+        return basicAuthChallengeResponse();
+    }
+
+    const credentials = basicAuthentication(context.request);
+    if (credentials instanceof Response) {
+        return credentials;
+    }
+
+    if (context.env.BASIC_USER !== credentials.user || context.env.BASIC_PASS !== credentials.pass) {
+        return unauthorizedResponse('Invalid credentials.');
+    }
+
+    return context.next();
   }
   
   export const onRequest = [errorHandling, authentication];

--- a/functions/api/manage/block/[id].js
+++ b/functions/api/manage/block/[id].js
@@ -1,23 +1,12 @@
-export async function onRequest(context) {
-    // Contents of context object
-    const {
-      request, // same as existing Worker API
-      env, // same as existing Worker API
-      params, // if filename includes [id] or [[path]]
-      waitUntil, // same as ctx.waitUntil in existing Worker API
-      next, // used for middleware or to fetch assets
-      data, // arbitrary space for passing data between middlewares
-    } = context;
-    console.log(env)
-    console.log(params.id)
-    //read the metadata
-    const value = await env.img_url.getWithMetadata(params.id);
-    console.log(value)
-    //"metadata":{"TimeStamp":19876541,"ListType":"None","rating_label":"None"}
-    //change the metadata
-    value.metadata.ListType = "Block"
-    await env.img_url.put(params.id,"",{metadata: value.metadata});
-    const info = JSON.stringify(value.metadata);
-    return new Response(info);
+import { LIST_TYPE, updateMetadata } from "../../../utils/metadata.js";
+import { jsonResponse } from "../../../utils/http.js";
 
-  }
+export async function onRequest(context) {
+    const { env, params } = context;
+    const metadata = await updateMetadata(env, params.id, current => {
+        current.ListType = LIST_TYPE.BLOCK;
+        return current;
+    });
+
+    return jsonResponse(metadata);
+}

--- a/functions/api/manage/check.js
+++ b/functions/api/manage/check.js
@@ -1,17 +1,9 @@
+import { isEmptyBinding, textResponse } from "../../utils/http.js";
+
 export async function onRequest(context) {
-    // Contents of context object
-    const {
-      request, // same as existing Worker API
-      env, // same as existing Worker API
-      params, // if filename includes [id] or [[path]]
-      waitUntil, // same as ctx.waitUntil in existing Worker API
-      next, // used for middleware or to fetch assets
-      data, // arbitrary space for passing data between middlewares
-    } = context;
-    if(typeof context.env.BASIC_USER == "undefined" || context.env.BASIC_USER == null || context.env.BASIC_USER == ""){
-        return new Response('Not using basic auth.', { status: 200 });
-    }else{
-        return new Response('true', { status: 200 });
+    if (isEmptyBinding(context.env.BASIC_USER)) {
+        return textResponse('Not using basic auth.', { status: 200 });
     }
 
-  }
+    return textResponse('true', { status: 200 });
+}

--- a/functions/api/manage/delete/[id].js
+++ b/functions/api/manage/delete/[id].js
@@ -1,17 +1,7 @@
-export async function onRequest(context) {
-    // Contents of context object
-    const {
-      request, // same as existing Worker API
-      env, // same as existing Worker API
-      params, // if filename includes [id] or [[path]]
-      waitUntil, // same as ctx.waitUntil in existing Worker API
-      next, // used for middleware or to fetch assets
-      data, // arbitrary space for passing data between middlewares
-    } = context;
-    console.log(env)
-    console.log(params.id)
-    await env.img_url.delete(params.id);
-    const info = JSON.stringify(params.id);
-    return new Response(info);
+import { jsonResponse } from "../../../utils/http.js";
 
-  }
+export async function onRequest(context) {
+    const { env, params } = context;
+    await env.img_url.delete(params.id);
+    return jsonResponse(params.id);
+}

--- a/functions/api/manage/editName/[id].js
+++ b/functions/api/manage/editName/[id].js
@@ -1,22 +1,19 @@
+import { jsonResponse, textResponse } from "../../../utils/http.js";
+import { updateMetadata } from "../../../utils/metadata.js";
+
 export async function onRequest(context) {
-    const { params, env } = context;
+    const { request, params, env } = context;
 
-    console.log("Request ID:", params.id);
-
-    // 获取元数据
-    const value = await env.img_url.getWithMetadata(params.id);
-    console.log("Current metadata:", value);
-
-    // 如果记录不存在
-    if (!value.metadata) return new Response(`Image metadata not found for ID: ${params.id}`, { status: 404 });
-
-    // 更新文件名
-    value.metadata.fileName = params.name;
-    await env.img_url.put(params.id, "", { metadata: value.metadata });
-
-    console.log("Updated metadata:", value.metadata);
-
-    return new Response(JSON.stringify({ success: true, fileName: value.metadata.fileName }), {
-        headers: { 'Content-Type': 'application/json' },
+    const url = new URL(request.url);
+    const fileName = url.searchParams.get('newName') || params.name;
+    const metadata = await updateMetadata(env, params.id, current => {
+        current.fileName = fileName;
+        return current;
     });
+
+    if (!metadata) {
+        return textResponse(`Image metadata not found for ID: ${params.id}`, { status: 404 });
+    }
+
+    return jsonResponse({ success: true, fileName: metadata.fileName });
 }

--- a/functions/api/manage/list.js
+++ b/functions/api/manage/list.js
@@ -1,3 +1,5 @@
+import { jsonResponse } from "../../utils/http.js";
+
 export async function onRequest(context) {
   const { request, env } = context;
   const url = new URL(request.url);
@@ -11,7 +13,5 @@ export async function onRequest(context) {
   const prefix = url.searchParams.get("prefix") || undefined;
   const value = await env.img_url.list({ limit, cursor, prefix });
 
-  return new Response(JSON.stringify(value), {
-    headers: { "Content-Type": "application/json" }
-  });
+  return jsonResponse(value);
 }

--- a/functions/api/manage/toggleLike/[id].js
+++ b/functions/api/manage/toggleLike/[id].js
@@ -1,22 +1,17 @@
+import { jsonResponse, textResponse } from "../../../utils/http.js";
+import { updateMetadata } from "../../../utils/metadata.js";
+
 export async function onRequest(context) {
     const { params, env } = context;
 
-    console.log("Request ID:", params.id);
-
-    // 获取元数据
-    const value = await env.img_url.getWithMetadata(params.id);
-    console.log("Current metadata:", value);
-
-    // 如果记录不存在
-    if (!value.metadata) return new Response(`Image metadata not found for ID: ${params.id}`, { status: 404 });
-
-    // 切换 liked 状态并更新
-    value.metadata.liked = !value.metadata.liked;
-    await env.img_url.put(params.id, "", { metadata: value.metadata });
-
-    console.log("Updated metadata:", value.metadata);
-
-    return new Response(JSON.stringify({ success: true, liked: value.metadata.liked }), {
-        headers: { 'Content-Type': 'application/json' },
+    const metadata = await updateMetadata(env, params.id, current => {
+        current.liked = !current.liked;
+        return current;
     });
+
+    if (!metadata) {
+        return textResponse(`Image metadata not found for ID: ${params.id}`, { status: 404 });
+    }
+
+    return jsonResponse({ success: true, liked: metadata.liked });
 }

--- a/functions/api/manage/white/[id].js
+++ b/functions/api/manage/white/[id].js
@@ -1,23 +1,12 @@
-export async function onRequest(context) {
-    // Contents of context object
-    const {
-      request, // same as existing Worker API
-      env, // same as existing Worker API
-      params, // if filename includes [id] or [[path]]
-      waitUntil, // same as ctx.waitUntil in existing Worker API
-      next, // used for middleware or to fetch assets
-      data, // arbitrary space for passing data between middlewares
-    } = context;
-    console.log(env)
-    console.log(params.id)
-    //read the metadata
-    const value = await env.img_url.getWithMetadata(params.id);
-    console.log(value)
-    //"metadata":{"TimeStamp":19876541,"ListType":"None","rating_label":"None"}
-    //change the metadata
-    value.metadata.ListType = "White"
-    await env.img_url.put(params.id,"",{metadata: value.metadata});
-    const info = JSON.stringify(value.metadata);
-    return new Response(info);
+import { LIST_TYPE, updateMetadata } from "../../../utils/metadata.js";
+import { jsonResponse } from "../../../utils/http.js";
 
-  }
+export async function onRequest(context) {
+    const { env, params } = context;
+    const metadata = await updateMetadata(env, params.id, current => {
+        current.ListType = LIST_TYPE.WHITE;
+        return current;
+    });
+
+    return jsonResponse(metadata);
+}

--- a/functions/file/[id].js
+++ b/functions/file/[id].js
@@ -1,3 +1,11 @@
+import {
+    getOrCreateMetadata,
+    isBlocked,
+    isWhitelisted,
+    putMetadata,
+} from "../utils/metadata.js";
+import { getTelegramFilePath } from "../utils/telegram.js";
+
 export async function onRequest(context) {
     const {
         request,
@@ -6,23 +14,7 @@ export async function onRequest(context) {
     } = context;
 
     const url = new URL(request.url);
-    let fileUrl = 'https://telegra.ph/' + url.pathname + url.search
-    if (url.pathname.length > 39) { // Path length > 39 indicates file uploaded via Telegram Bot API
-        const formdata = new FormData();
-        formdata.append("file_id", url.pathname);
-
-        const requestOptions = {
-            method: "POST",
-            body: formdata,
-            redirect: "follow"
-        };
-        // /file/AgACAgEAAxkDAAMDZt1Gzs4W8dQPWiQJxO5YSH5X-gsAAt-sMRuWNelGOSaEM_9lHHgBAAMCAANtAAM2BA.png
-        //get the AgACAgEAAxkDAAMDZt1Gzs4W8dQPWiQJxO5YSH5X-gsAAt-sMRuWNelGOSaEM_9lHHgBAAMCAANtAAM2BA
-        console.log(url.pathname.split(".")[0].split("/")[2])
-        const filePath = await getFilePath(env, url.pathname.split(".")[0].split("/")[2]);
-        console.log(filePath)
-        fileUrl = `https://api.telegram.org/file/bot${env.TG_Bot_Token}/${filePath}`;
-    }
+    const fileUrl = await resolveFileUrl(env, url);
 
     const response = await fetch(fileUrl, {
         method: request.method,
@@ -32,9 +24,6 @@ export async function onRequest(context) {
 
     // If the response is OK, proceed with further checks
     if (!response.ok) return response;
-
-    // Log response details
-    console.log(response.ok, response.status);
 
     // Allow the admin page to directly view the image
     const isAdmin = request.headers.get('Referer')?.includes(`${url.origin}/admin`);
@@ -48,37 +37,12 @@ export async function onRequest(context) {
         return response;  // Directly return image response, terminate execution
     }
 
-    // The following code executes only if KV is available
-    let record = await env.img_url.getWithMetadata(params.id);
-    if (!record || !record.metadata) {
-        // Initialize metadata if it doesn't exist
-        console.log("Metadata not found, initializing...");
-        record = {
-            metadata: {
-                ListType: "None",
-                Label: "None",
-                TimeStamp: Date.now(),
-                liked: false,
-                fileName: params.id,
-                fileSize: 0,
-            }
-        };
-        await env.img_url.put(params.id, "", { metadata: record.metadata });
-    }
-
-    const metadata = {
-        ListType: record.metadata.ListType || "None",
-        Label: record.metadata.Label || "None",
-        TimeStamp: record.metadata.TimeStamp || Date.now(),
-        liked: record.metadata.liked !== undefined ? record.metadata.liked : false,
-        fileName: record.metadata.fileName || params.id,
-        fileSize: record.metadata.fileSize || 0,
-    };
+    const metadata = await getOrCreateMetadata(env, params.id);
 
     // Handle based on ListType and Label
-    if (metadata.ListType === "White") {
+    if (isWhitelisted(metadata)) {
         return response;
-    } else if (metadata.ListType === "Block" || metadata.Label === "adult") {
+    } else if (isBlocked(metadata)) {
         const referer = request.headers.get('Referer');
         const redirectUrl = referer ? "https://static-res.pages.dev/teleimage/img-block-compressed.png" : `${url.origin}/block-img.html`;
         return Response.redirect(redirectUrl, 302);
@@ -90,66 +54,54 @@ export async function onRequest(context) {
     }
 
     // If no metadata or further actions required, moderate content and add to KV if needed
-    if (env.ModerateContentApiKey) {
-        try {
-            console.log("Starting content moderation...");
-            const moderateUrl = `https://api.moderatecontent.com/moderate/?key=${env.ModerateContentApiKey}&url=https://telegra.ph${url.pathname}${url.search}`;
-            const moderateResponse = await fetch(moderateUrl);
-
-            if (!moderateResponse.ok) {
-                console.error("Content moderation API request failed: " + moderateResponse.status);
-            } else {
-                const moderateData = await moderateResponse.json();
-                console.log("Content moderation results:", moderateData);
-
-                if (moderateData && moderateData.rating_label) {
-                    metadata.Label = moderateData.rating_label;
-
-                    if (moderateData.rating_label === "adult") {
-                        console.log("Content marked as adult, saving metadata and redirecting");
-                        await env.img_url.put(params.id, "", { metadata });
-                        return Response.redirect(`${url.origin}/block-img.html`, 302);
-                    }
-                }
-            }
-        } catch (error) {
-            console.error("Error during content moderation: " + error.message);
-            // Moderation failure should not affect user experience, continue processing
-        }
+    const moderationResult = await moderateFile(env, url, metadata);
+    if (moderationResult.blocked) {
+        await putMetadata(env, params.id, metadata);
+        return Response.redirect(`${url.origin}/block-img.html`, 302);
     }
 
     // Only save metadata if content is not adult content
     // Adult content cases are already handled above and will not reach this point
-    console.log("Saving metadata");
-    await env.img_url.put(params.id, "", { metadata });
+    await putMetadata(env, params.id, metadata);
 
     // Return file content
     return response;
 }
 
-async function getFilePath(env, file_id) {
+async function resolveFileUrl(env, url) {
+    let fileUrl = 'https://telegra.ph/' + url.pathname + url.search;
+
+    if (url.pathname.length > 39) { // Path length > 39 indicates file uploaded via Telegram Bot API
+        const fileId = url.pathname.split(".")[0].split("/")[2];
+        const filePath = await getTelegramFilePath(env, fileId);
+        fileUrl = `https://api.telegram.org/file/bot${env.TG_Bot_Token}/${filePath}`;
+    }
+
+    return fileUrl;
+}
+
+async function moderateFile(env, url, metadata) {
+    if (!env.ModerateContentApiKey) {
+        return { blocked: false };
+    }
+
     try {
-        const url = `https://api.telegram.org/bot${env.TG_Bot_Token}/getFile?file_id=${file_id}`;
-        const res = await fetch(url, {
-            method: 'GET',
-        });
+        const moderateUrl = `https://api.moderatecontent.com/moderate/?key=${env.ModerateContentApiKey}&url=https://telegra.ph${url.pathname}${url.search}`;
+        const moderateResponse = await fetch(moderateUrl);
 
-        if (!res.ok) {
-            console.error(`HTTP error! status: ${res.status}`);
-            return null;
+        if (!moderateResponse.ok) {
+            console.error("Content moderation API request failed: " + moderateResponse.status);
+            return { blocked: false };
         }
 
-        const responseData = await res.json();
-        const { ok, result } = responseData;
-
-        if (ok && result) {
-            return result.file_path;
-        } else {
-            console.error('Error in response data:', responseData);
-            return null;
+        const moderateData = await moderateResponse.json();
+        if (moderateData?.rating_label) {
+            metadata.Label = moderateData.rating_label;
         }
+
+        return { blocked: isBlocked(metadata) };
     } catch (error) {
-        console.error('Error fetching file path:', error.message);
-        return null;
+        console.error("Error during content moderation: " + error.message);
+        return { blocked: false };
     }
 }

--- a/functions/file/_middleware.js
+++ b/functions/file/_middleware.js
@@ -1,3 +1,3 @@
-import { errorHandling, telemetryData } from '../utils/middleware';
+import { errorHandling, telemetryData } from '../utils/middleware.js';
 
 export const onRequest = [errorHandling, telemetryData];

--- a/functions/upload.js
+++ b/functions/upload.js
@@ -1,4 +1,12 @@
-import { errorHandling, telemetryData } from "./utils/middleware";
+import { errorHandling, telemetryData } from "./utils/middleware.js";
+import { jsonResponse } from "./utils/http.js";
+import { createDefaultMetadata, putMetadata } from "./utils/metadata.js";
+import {
+    createTelegramFormData,
+    getFileId,
+    getUploadTarget,
+    sendToTelegram,
+} from "./utils/telegram.js";
 
 export async function onRequestPost(context) {
     const { request, env } = context;
@@ -18,26 +26,10 @@ export async function onRequestPost(context) {
         const fileName = uploadFile.name;
         const fileExtension = fileName.split('.').pop().toLowerCase();
 
-        const telegramFormData = new FormData();
-        telegramFormData.append("chat_id", env.TG_Chat_ID);
+        const { endpoint, field } = getUploadTarget(uploadFile);
+        const telegramFormData = createTelegramFormData(env.TG_Chat_ID, field, uploadFile);
 
-        // 根据文件类型选择合适的上传方式
-        let apiEndpoint;
-        if (uploadFile.type.startsWith('image/')) {
-            telegramFormData.append("photo", uploadFile);
-            apiEndpoint = 'sendPhoto';
-        } else if (uploadFile.type.startsWith('audio/')) {
-            telegramFormData.append("audio", uploadFile);
-            apiEndpoint = 'sendAudio';
-        } else if (uploadFile.type.startsWith('video/')) {
-            telegramFormData.append("video", uploadFile);
-            apiEndpoint = 'sendVideo';
-        } else {
-            telegramFormData.append("document", uploadFile);
-            apiEndpoint = 'sendDocument';
-        }
-
-        const result = await sendToTelegram(telegramFormData, apiEndpoint, env);
+        const result = await sendToTelegram(telegramFormData, endpoint, env);
 
         if (!result.success) {
             throw new Error(result.error);
@@ -51,84 +43,15 @@ export async function onRequestPost(context) {
 
         // 将文件信息保存到 KV 存储
         if (env.img_url) {
-            await env.img_url.put(`${fileId}.${fileExtension}`, "", {
-                metadata: {
-                    TimeStamp: Date.now(),
-                    ListType: "None",
-                    Label: "None",
-                    liked: false,
-                    fileName: fileName,
-                    fileSize: uploadFile.size,
-                }
-            });
+            await putMetadata(env, `${fileId}.${fileExtension}`, createDefaultMetadata(`${fileId}.${fileExtension}`, {
+                fileName,
+                fileSize: uploadFile.size,
+            }));
         }
 
-        return new Response(
-            JSON.stringify([{ 'src': `/file/${fileId}.${fileExtension}` }]),
-            {
-                status: 200,
-                headers: { 'Content-Type': 'application/json' }
-            }
-        );
+        return jsonResponse([{ 'src': `/file/${fileId}.${fileExtension}` }]);
     } catch (error) {
         console.error('Upload error:', error);
-        return new Response(
-            JSON.stringify({ error: error.message }),
-            {
-                status: 500,
-                headers: { 'Content-Type': 'application/json' }
-            }
-        );
-    }
-}
-
-function getFileId(response) {
-    if (!response.ok || !response.result) return null;
-
-    const result = response.result;
-    if (result.photo) {
-        return result.photo.reduce((prev, current) =>
-            (prev.file_size > current.file_size) ? prev : current
-        ).file_id;
-    }
-    if (result.document) return result.document.file_id;
-    if (result.video) return result.video.file_id;
-    if (result.audio) return result.audio.file_id;
-
-    return null;
-}
-
-async function sendToTelegram(formData, apiEndpoint, env, retryCount = 0) {
-    const MAX_RETRIES = 2;
-    const apiUrl = `https://api.telegram.org/bot${env.TG_Bot_Token}/${apiEndpoint}`;
-
-    try {
-        const response = await fetch(apiUrl, { method: "POST", body: formData });
-        const responseData = await response.json();
-
-        if (response.ok) {
-            return { success: true, data: responseData };
-        }
-
-        // 图片上传失败时转为文档方式重试
-        if (retryCount < MAX_RETRIES && apiEndpoint === 'sendPhoto') {
-            console.log('Retrying image as document...');
-            const newFormData = new FormData();
-            newFormData.append('chat_id', formData.get('chat_id'));
-            newFormData.append('document', formData.get('photo'));
-            return await sendToTelegram(newFormData, 'sendDocument', env, retryCount + 1);
-        }
-
-        return {
-            success: false,
-            error: responseData.description || 'Upload to Telegram failed'
-        };
-    } catch (error) {
-        console.error('Network error:', error);
-        if (retryCount < MAX_RETRIES) {
-            await new Promise(resolve => setTimeout(resolve, 1000 * (retryCount + 1)));
-            return await sendToTelegram(formData, apiEndpoint, env, retryCount + 1);
-        }
-        return { success: false, error: 'Network error occurred' };
+        return jsonResponse({ error: error.message }, { status: 500 });
     }
 }

--- a/functions/utils/auth.js
+++ b/functions/utils/auth.js
@@ -1,0 +1,63 @@
+import { textResponse } from './http.js';
+
+export const DASHBOARD_DISABLED_MESSAGE = 'Dashboard is disabled. Please bind a KV namespace to use this feature.';
+export const BASIC_AUTH_CHALLENGE = 'Basic realm="my scope", charset="UTF-8"';
+
+export function basicAuthentication(request) {
+  const authorization = request.headers.get('Authorization') || '';
+  const [scheme, encoded] = authorization.split(' ');
+
+  if (!encoded || scheme !== 'Basic') {
+    return badRequestResponse('Malformed authorization header.');
+  }
+
+  const buffer = Uint8Array.from(atob(encoded), character => character.charCodeAt(0));
+  const decoded = new TextDecoder().decode(buffer).normalize();
+  const index = decoded.indexOf(':');
+
+  if (index === -1 || /[\0-\x1F\x7F]/.test(decoded)) {
+    return badRequestResponse('Invalid authorization value.');
+  }
+
+  return {
+    user: decoded.substring(0, index),
+    pass: decoded.substring(index + 1),
+  };
+}
+
+export function dashboardDisabledResponse() {
+  return textResponse(DASHBOARD_DISABLED_MESSAGE, { status: 200 });
+}
+
+export function basicAuthChallengeResponse() {
+  return textResponse('You need to login.', {
+    status: 401,
+    headers: {
+      'WWW-Authenticate': BASIC_AUTH_CHALLENGE,
+    },
+  });
+}
+
+export function unauthorizedResponse(reason) {
+  return textResponse(reason, {
+    status: 401,
+    statusText: 'Unauthorized',
+    headers: plainTextHeaders(reason),
+  });
+}
+
+function badRequestResponse(reason) {
+  return textResponse(reason, {
+    status: 400,
+    statusText: 'Bad Request',
+    headers: plainTextHeaders(reason),
+  });
+}
+
+function plainTextHeaders(reason) {
+  return {
+    'Content-Type': 'text/plain;charset=UTF-8',
+    'Cache-Control': 'no-store',
+    'Content-Length': reason.length,
+  };
+}

--- a/functions/utils/http.js
+++ b/functions/utils/http.js
@@ -1,0 +1,19 @@
+export function jsonResponse(data, init = {}) {
+  const headers = new Headers(init.headers || {});
+  if (!headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json');
+  }
+
+  return new Response(JSON.stringify(data), {
+    ...init,
+    headers,
+  });
+}
+
+export function textResponse(body, init = {}) {
+  return new Response(body, init);
+}
+
+export function isEmptyBinding(value) {
+  return typeof value === 'undefined' || value === null || value === '';
+}

--- a/functions/utils/metadata.js
+++ b/functions/utils/metadata.js
@@ -1,0 +1,71 @@
+export const LIST_TYPE = {
+  NONE: 'None',
+  WHITE: 'White',
+  BLOCK: 'Block',
+};
+
+export const LABEL = {
+  NONE: 'None',
+  ADULT: 'adult',
+};
+
+export function createDefaultMetadata(id, overrides = {}) {
+  return {
+    TimeStamp: Date.now(),
+    ListType: LIST_TYPE.NONE,
+    Label: LABEL.NONE,
+    liked: false,
+    fileName: id,
+    fileSize: 0,
+    ...overrides,
+  };
+}
+
+export function normalizeMetadata(metadata, id) {
+  return {
+    ListType: metadata.ListType || LIST_TYPE.NONE,
+    Label: metadata.Label || LABEL.NONE,
+    TimeStamp: metadata.TimeStamp || Date.now(),
+    liked: metadata.liked !== undefined ? metadata.liked : false,
+    fileName: metadata.fileName || id,
+    fileSize: metadata.fileSize || 0,
+  };
+}
+
+export async function getMetadata(env, id) {
+  const record = await env.img_url.getWithMetadata(id);
+  return record?.metadata || null;
+}
+
+export async function getOrCreateMetadata(env, id) {
+  const record = await env.img_url.getWithMetadata(id);
+
+  if (record?.metadata) {
+    return normalizeMetadata(record.metadata, id);
+  }
+
+  const metadata = createDefaultMetadata(id);
+  await putMetadata(env, id, metadata);
+  return metadata;
+}
+
+export async function putMetadata(env, id, metadata) {
+  await env.img_url.put(id, '', { metadata });
+}
+
+export async function updateMetadata(env, id, updater) {
+  const metadata = await getMetadata(env, id);
+  if (!metadata) return null;
+
+  const updated = updater(metadata);
+  await putMetadata(env, id, updated);
+  return updated;
+}
+
+export function isBlocked(metadata) {
+  return metadata.ListType === LIST_TYPE.BLOCK || metadata.Label === LABEL.ADULT;
+}
+
+export function isWhitelisted(metadata) {
+  return metadata.ListType === LIST_TYPE.WHITE;
+}

--- a/functions/utils/telegram.js
+++ b/functions/utils/telegram.js
@@ -1,0 +1,98 @@
+const MAX_RETRIES = 2;
+
+export function getUploadTarget(file) {
+  if (file.type.startsWith('image/')) {
+    return { endpoint: 'sendPhoto', field: 'photo' };
+  }
+
+  if (file.type.startsWith('audio/')) {
+    return { endpoint: 'sendAudio', field: 'audio' };
+  }
+
+  if (file.type.startsWith('video/')) {
+    return { endpoint: 'sendVideo', field: 'video' };
+  }
+
+  return { endpoint: 'sendDocument', field: 'document' };
+}
+
+export function createTelegramFormData(chatId, field, file) {
+  const formData = new FormData();
+  formData.append('chat_id', chatId);
+  formData.append(field, file);
+  return formData;
+}
+
+export function getFileId(response) {
+  if (!response.ok || !response.result) return null;
+
+  const result = response.result;
+  if (result.photo) {
+    return result.photo.reduce((prev, current) =>
+      (prev.file_size > current.file_size) ? prev : current
+    ).file_id;
+  }
+  if (result.document) return result.document.file_id;
+  if (result.video) return result.video.file_id;
+  if (result.audio) return result.audio.file_id;
+
+  return null;
+}
+
+export async function sendToTelegram(formData, apiEndpoint, env, retryCount = 0) {
+  const apiUrl = `https://api.telegram.org/bot${env.TG_Bot_Token}/${apiEndpoint}`;
+
+  try {
+    const response = await fetch(apiUrl, { method: 'POST', body: formData });
+    const responseData = await response.json();
+
+    if (response.ok) {
+      return { success: true, data: responseData };
+    }
+
+    if (retryCount < MAX_RETRIES && apiEndpoint === 'sendPhoto') {
+      console.log('Retrying image as document...');
+      const newFormData = new FormData();
+      newFormData.append('chat_id', formData.get('chat_id'));
+      newFormData.append('document', formData.get('photo'));
+      return await sendToTelegram(newFormData, 'sendDocument', env, retryCount + 1);
+    }
+
+    return {
+      success: false,
+      error: responseData.description || 'Upload to Telegram failed',
+    };
+  } catch (error) {
+    console.error('Network error:', error);
+    if (retryCount < MAX_RETRIES) {
+      await new Promise(resolve => setTimeout(resolve, 1000 * (retryCount + 1)));
+      return await sendToTelegram(formData, apiEndpoint, env, retryCount + 1);
+    }
+    return { success: false, error: 'Network error occurred' };
+  }
+}
+
+export async function getTelegramFilePath(env, fileId) {
+  try {
+    const url = `https://api.telegram.org/bot${env.TG_Bot_Token}/getFile?file_id=${fileId}`;
+    const res = await fetch(url, { method: 'GET' });
+
+    if (!res.ok) {
+      console.error(`HTTP error! status: ${res.status}`);
+      return null;
+    }
+
+    const responseData = await res.json();
+    const { ok, result } = responseData;
+
+    if (ok && result) {
+      return result.file_path;
+    }
+
+    console.error('Error in response data:', responseData);
+    return null;
+  } catch (error) {
+    console.error('Error fetching file path:', error.message);
+    return null;
+  }
+}

--- a/test/file-proxy.test.js
+++ b/test/file-proxy.test.js
@@ -1,0 +1,248 @@
+const assert = require('assert');
+const { createMockKV, installFetchMock, makeContext, muteConsole } = require('./helpers');
+
+const baseMetadata = {
+  TimeStamp: 1710000000000,
+  ListType: 'None',
+  Label: 'None',
+  liked: false,
+  fileName: 'cat.png',
+  fileSize: 123,
+};
+
+describe('file proxy function', function () {
+  let restoreConsole;
+  let fetchMock;
+
+  beforeEach(function () {
+    restoreConsole = muteConsole();
+  });
+
+  afterEach(function () {
+    if (fetchMock) {
+      fetchMock.restore();
+      fetchMock = null;
+    }
+    restoreConsole();
+  });
+
+  async function getOnRequest() {
+    return (await import('../functions/file/[id].js')).onRequest;
+  }
+
+  it('proxies Telegraph files and initializes missing metadata in KV', async function () {
+    const onRequest = await getOnRequest();
+    const img_url = createMockKV();
+
+    fetchMock = installFetchMock(async input => {
+      assert.strictEqual(String(input), 'https://telegra.ph//file/cat.png?size=large');
+      return new Response('image-body', {
+        status: 200,
+        headers: { 'Content-Type': 'image/png' },
+      });
+    });
+
+    const request = new Request('https://example.com/file/cat.png?size=large');
+    const res = await onRequest(makeContext({
+      request,
+      env: { img_url },
+      params: { id: 'cat.png' },
+    }));
+
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(await res.text(), 'image-body');
+    assert.strictEqual(fetchMock.calls.length, 1);
+
+    const stored = img_url.snapshot('cat.png');
+    assert.strictEqual(stored.value, '');
+    assert.strictEqual(stored.metadata.ListType, 'None');
+    assert.strictEqual(stored.metadata.Label, 'None');
+    assert.strictEqual(stored.metadata.fileName, 'cat.png');
+    assert.strictEqual(stored.metadata.fileSize, 0);
+    assert.strictEqual(stored.metadata.liked, false);
+    assert.ok(Number.isFinite(stored.metadata.TimeStamp));
+  });
+
+  it('returns proxied files directly when KV is not bound', async function () {
+    const onRequest = await getOnRequest();
+
+    fetchMock = installFetchMock(async input => {
+      assert.strictEqual(String(input), 'https://telegra.ph//file/cat.png');
+      return new Response('image-body', {
+        status: 200,
+        headers: { 'Content-Type': 'image/png' },
+      });
+    });
+
+    const res = await onRequest(makeContext({
+      request: new Request('https://example.com/file/cat.png'),
+      env: {},
+      params: { id: 'cat.png' },
+    }));
+
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(res.headers.get('Content-Type'), 'image/png');
+    assert.strictEqual(await res.text(), 'image-body');
+  });
+
+  it('redirects blocked files to the blocked image page', async function () {
+    const onRequest = await getOnRequest();
+    const img_url = createMockKV({
+      'cat.png': { ...baseMetadata, ListType: 'Block' },
+    });
+
+    fetchMock = installFetchMock(async () => new Response('image-body', { status: 200 }));
+
+    const res = await onRequest(makeContext({
+      request: new Request('https://example.com/file/cat.png'),
+      env: { img_url },
+      params: { id: 'cat.png' },
+    }));
+
+    assert.strictEqual(res.status, 302);
+    assert.strictEqual(res.headers.get('Location'), 'https://example.com/block-img.html');
+  });
+
+  it('runs moderation and stores the returned label for allowed files', async function () {
+    const onRequest = await getOnRequest();
+    const img_url = createMockKV({
+      'cat.png': baseMetadata,
+    });
+
+    fetchMock = installFetchMock(async (input, init, calls) => {
+      if (calls.length === 1) {
+        assert.strictEqual(String(input), 'https://telegra.ph//file/cat.png');
+        return new Response('image-body', { status: 200 });
+      }
+
+      assert.strictEqual(String(input), 'https://api.moderatecontent.com/moderate/?key=moderate-key&url=https://telegra.ph/file/cat.png');
+      return Response.json({ rating_label: 'everyone' });
+    });
+
+    const res = await onRequest(makeContext({
+      request: new Request('https://example.com/file/cat.png'),
+      env: { img_url, ModerateContentApiKey: 'moderate-key' },
+      params: { id: 'cat.png' },
+    }));
+
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(await res.text(), 'image-body');
+    assert.strictEqual(img_url.snapshot('cat.png').metadata.Label, 'everyone');
+  });
+
+  it('runs moderation and redirects adult files after saving metadata', async function () {
+    const onRequest = await getOnRequest();
+    const img_url = createMockKV({
+      'cat.png': baseMetadata,
+    });
+
+    fetchMock = installFetchMock(async (input, init, calls) => {
+      if (calls.length === 1) {
+        assert.strictEqual(String(input), 'https://telegra.ph//file/cat.png');
+        return new Response('image-body', { status: 200 });
+      }
+
+      assert.strictEqual(String(input), 'https://api.moderatecontent.com/moderate/?key=moderate-key&url=https://telegra.ph/file/cat.png');
+      return Response.json({ rating_label: 'adult' });
+    });
+
+    const res = await onRequest(makeContext({
+      request: new Request('https://example.com/file/cat.png'),
+      env: { img_url, ModerateContentApiKey: 'moderate-key' },
+      params: { id: 'cat.png' },
+    }));
+
+    assert.strictEqual(res.status, 302);
+    assert.strictEqual(res.headers.get('Location'), 'https://example.com/block-img.html');
+    assert.strictEqual(img_url.snapshot('cat.png').metadata.Label, 'adult');
+  });
+
+  it('redirects non-whitelisted files when whitelist mode is enabled', async function () {
+    const onRequest = await getOnRequest();
+    const img_url = createMockKV({
+      'cat.png': baseMetadata,
+    });
+
+    fetchMock = installFetchMock(async () => new Response('image-body', { status: 200 }));
+
+    const res = await onRequest(makeContext({
+      request: new Request('https://example.com/file/cat.png'),
+      env: { img_url, WhiteList_Mode: 'true' },
+      params: { id: 'cat.png' },
+    }));
+
+    assert.strictEqual(res.status, 302);
+    assert.strictEqual(res.headers.get('Location'), 'https://example.com/whitelist-on.html');
+  });
+
+  it('returns whitelisted files even when whitelist mode is enabled', async function () {
+    const onRequest = await getOnRequest();
+    const img_url = createMockKV({
+      'cat.png': { ...baseMetadata, ListType: 'White' },
+    });
+
+    fetchMock = installFetchMock(async () => new Response('image-body', { status: 200 }));
+
+    const res = await onRequest(makeContext({
+      request: new Request('https://example.com/file/cat.png'),
+      env: { img_url, WhiteList_Mode: 'true' },
+      params: { id: 'cat.png' },
+    }));
+
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(await res.text(), 'image-body');
+    assert.deepStrictEqual(img_url.operations.put, []);
+  });
+
+  it('uses Telegram getFile for long Bot API file ids before proxying content', async function () {
+    const onRequest = await getOnRequest();
+    const telegramFileId = 'AgACAgEAAxkDAAMDZt1Gzs4W8dQPWiQJxO5YSH5X-gsAAt-sMRuWNelGOSaEM_9lHHgBAAMCAANtAAM2BA';
+    const fileName = `${telegramFileId}.png`;
+    const img_url = createMockKV({
+      [fileName]: baseMetadata,
+    });
+
+    fetchMock = installFetchMock(async (input, init, calls) => {
+      if (calls.length === 1) {
+        assert.strictEqual(String(input), `https://api.telegram.org/botbot-token/getFile?file_id=${telegramFileId}`);
+        return Response.json({
+          ok: true,
+          result: { file_path: 'photos/file_1.png' },
+        });
+      }
+
+      assert.strictEqual(String(input), 'https://api.telegram.org/file/botbot-token/photos/file_1.png');
+      assert.strictEqual(init.method, 'GET');
+      return new Response('telegram-file', { status: 200 });
+    });
+
+    const res = await onRequest(makeContext({
+      request: new Request(`https://example.com/file/${fileName}`),
+      env: { img_url, TG_Bot_Token: 'bot-token' },
+      params: { id: fileName },
+    }));
+
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(await res.text(), 'telegram-file');
+    assert.strictEqual(fetchMock.calls.length, 2);
+  });
+
+  it('skips KV writes for admin referers', async function () {
+    const onRequest = await getOnRequest();
+    const img_url = createMockKV();
+    const headers = new Headers({ Referer: 'https://example.com/admin.html' });
+
+    fetchMock = installFetchMock(async () => new Response('image-body', { status: 200 }));
+
+    const res = await onRequest(makeContext({
+      request: new Request('https://example.com/file/cat.png', { headers }),
+      env: { img_url },
+      params: { id: 'cat.png' },
+    }));
+
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(await res.text(), 'image-body');
+    assert.deepStrictEqual(img_url.operations.get, []);
+    assert.deepStrictEqual(img_url.operations.put, []);
+  });
+});

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,125 @@
+const assert = require('assert');
+
+function clone(value) {
+  return value == null ? value : JSON.parse(JSON.stringify(value));
+}
+
+function normalizeEntry(entry) {
+  if (entry && Object.prototype.hasOwnProperty.call(entry, 'metadata')) {
+    return {
+      value: Object.prototype.hasOwnProperty.call(entry, 'value') ? entry.value : '',
+      metadata: clone(entry.metadata),
+    };
+  }
+
+  return {
+    value: '',
+    metadata: clone(entry),
+  };
+}
+
+function createMockKV(initial = {}) {
+  const store = new Map();
+  const operations = {
+    get: [],
+    put: [],
+    delete: [],
+    list: [],
+  };
+
+  for (const [key, entry] of Object.entries(initial)) {
+    store.set(key, normalizeEntry(entry));
+  }
+
+  return {
+    operations,
+    async getWithMetadata(key) {
+      operations.get.push(key);
+      const entry = store.get(key);
+      if (!entry) return { value: null, metadata: null };
+      return { value: entry.value, metadata: clone(entry.metadata) };
+    },
+    async put(key, value, options = {}) {
+      const metadata = clone(options.metadata);
+      operations.put.push({ key, value, metadata });
+      store.set(key, { value, metadata });
+    },
+    async delete(key) {
+      operations.delete.push(key);
+      store.delete(key);
+    },
+    async list(options = {}) {
+      operations.list.push({ ...options });
+      const limit = options.limit || 1000;
+      const prefix = options.prefix || '';
+      const start = options.cursor ? parseInt(options.cursor, 10) : 0;
+      const names = Array.from(store.keys()).filter(key => key.startsWith(prefix));
+      const keys = names.slice(start, start + limit).map(name => ({
+        name,
+        metadata: clone(store.get(name).metadata),
+      }));
+      const next = start + limit < names.length ? String(start + limit) : undefined;
+
+      return {
+        keys,
+        list_complete: !next,
+        cursor: next,
+      };
+    },
+    snapshot(key) {
+      const entry = store.get(key);
+      return entry ? clone(entry) : undefined;
+    },
+  };
+}
+
+function makeContext(overrides = {}) {
+  return {
+    request: overrides.request || new Request('https://example.com/'),
+    env: overrides.env || {},
+    params: overrides.params || {},
+    data: overrides.data || {},
+    waitUntil: overrides.waitUntil || (() => {}),
+    next: overrides.next || (async () => new Response('next')),
+  };
+}
+
+function installFetchMock(handler) {
+  const originalFetch = global.fetch;
+  const calls = [];
+
+  global.fetch = async (input, init = {}) => {
+    const url = input instanceof Request ? input.url : String(input);
+    const call = { input, init, url };
+    calls.push(call);
+    const result = await handler(input, init, calls);
+    assert.ok(result instanceof Response, 'fetch mock must return a Response');
+    return result;
+  };
+
+  return {
+    calls,
+    restore() {
+      global.fetch = originalFetch;
+    },
+  };
+}
+
+function muteConsole() {
+  const originalLog = console.log;
+  const originalError = console.error;
+  console.log = () => {};
+  console.error = () => {};
+
+  return () => {
+    console.log = originalLog;
+    console.error = originalError;
+  };
+}
+
+module.exports = {
+  createMockKV,
+  installFetchMock,
+  makeContext,
+  muteConsole,
+};

--- a/test/manage-api.test.js
+++ b/test/manage-api.test.js
@@ -1,0 +1,189 @@
+const assert = require('assert');
+const { createMockKV, makeContext, muteConsole } = require('./helpers');
+
+const baseMetadata = {
+  TimeStamp: 1710000000000,
+  ListType: 'None',
+  Label: 'None',
+  liked: false,
+  fileName: 'cat.png',
+  fileSize: 123,
+};
+
+describe('manage API functions', function () {
+  let restoreConsole;
+
+  beforeEach(function () {
+    restoreConsole = muteConsole();
+  });
+
+  afterEach(function () {
+    restoreConsole();
+  });
+
+  it('marks a record as blocked while preserving other metadata', async function () {
+    const { onRequest } = await import('../functions/api/manage/block/[id].js');
+    const img_url = createMockKV({ 'cat.png': baseMetadata });
+
+    const res = await onRequest(makeContext({
+      env: { img_url },
+      params: { id: 'cat.png' },
+    }));
+
+    assert.strictEqual(res.status, 200);
+    const metadata = JSON.parse(await res.text());
+    assert.strictEqual(metadata.ListType, 'Block');
+    assert.strictEqual(metadata.fileName, 'cat.png');
+    assert.deepStrictEqual(img_url.snapshot('cat.png').metadata, metadata);
+  });
+
+  it('marks a record as whitelisted while preserving other metadata', async function () {
+    const { onRequest } = await import('../functions/api/manage/white/[id].js');
+    const img_url = createMockKV({ 'cat.png': baseMetadata });
+
+    const res = await onRequest(makeContext({
+      env: { img_url },
+      params: { id: 'cat.png' },
+    }));
+
+    assert.strictEqual(res.status, 200);
+    const metadata = JSON.parse(await res.text());
+    assert.strictEqual(metadata.ListType, 'White');
+    assert.strictEqual(metadata.fileSize, 123);
+    assert.deepStrictEqual(img_url.snapshot('cat.png').metadata, metadata);
+  });
+
+  it('deletes a KV record and returns the deleted id', async function () {
+    const { onRequest } = await import('../functions/api/manage/delete/[id].js');
+    const img_url = createMockKV({ 'cat.png': baseMetadata });
+
+    const res = await onRequest(makeContext({
+      env: { img_url },
+      params: { id: 'cat.png' },
+    }));
+
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(await res.text(), '"cat.png"');
+    assert.deepStrictEqual(img_url.operations.delete, ['cat.png']);
+    assert.strictEqual(img_url.snapshot('cat.png'), undefined);
+  });
+
+  it('toggles the liked flag on an existing record', async function () {
+    const { onRequest } = await import('../functions/api/manage/toggleLike/[id].js');
+    const img_url = createMockKV({ 'cat.png': baseMetadata });
+
+    const res = await onRequest(makeContext({
+      env: { img_url },
+      params: { id: 'cat.png' },
+    }));
+
+    assert.strictEqual(res.status, 200);
+    assert.deepStrictEqual(JSON.parse(await res.text()), {
+      success: true,
+      liked: true,
+    });
+    assert.strictEqual(img_url.snapshot('cat.png').metadata.liked, true);
+  });
+
+  it('updates the display filename from the newName query parameter', async function () {
+    const { onRequest } = await import('../functions/api/manage/editName/[id].js');
+    const img_url = createMockKV({ 'cat.png': baseMetadata });
+
+    const res = await onRequest(makeContext({
+      request: new Request('https://example.com/api/manage/editName/cat.png?newName=kitten.png'),
+      env: { img_url },
+      params: { id: 'cat.png' },
+    }));
+
+    assert.strictEqual(res.status, 200);
+    assert.deepStrictEqual(JSON.parse(await res.text()), {
+      success: true,
+      fileName: 'kitten.png',
+    });
+    assert.strictEqual(img_url.snapshot('cat.png').metadata.fileName, 'kitten.png');
+  });
+
+  it('returns 404 when toggling liked on a missing record', async function () {
+    const { onRequest } = await import('../functions/api/manage/toggleLike/[id].js');
+    const img_url = createMockKV();
+
+    const res = await onRequest(makeContext({
+      env: { img_url },
+      params: { id: 'missing.png' },
+    }));
+
+    assert.strictEqual(res.status, 404);
+    assert.strictEqual(await res.text(), 'Image metadata not found for ID: missing.png');
+  });
+
+  it('reports whether dashboard basic auth is configured', async function () {
+    const { onRequest } = await import('../functions/api/manage/check.js');
+
+    const disabled = await onRequest(makeContext({ env: {} }));
+    assert.strictEqual(disabled.status, 200);
+    assert.strictEqual(await disabled.text(), 'Not using basic auth.');
+
+    const enabled = await onRequest(makeContext({ env: { BASIC_USER: 'admin' } }));
+    assert.strictEqual(enabled.status, 200);
+    assert.strictEqual(await enabled.text(), 'true');
+  });
+});
+
+describe('manage API authentication middleware', function () {
+  let restoreConsole;
+
+  beforeEach(function () {
+    restoreConsole = muteConsole();
+  });
+
+  afterEach(function () {
+    restoreConsole();
+  });
+
+  async function getAuthentication() {
+    const mod = await import('../functions/api/manage/_middleware.js');
+    return mod.onRequest[1];
+  }
+
+  it('blocks dashboard requests when basic auth is configured and absent', async function () {
+    const authentication = await getAuthentication();
+    const img_url = createMockKV();
+
+    const res = await authentication(makeContext({
+      env: { img_url, BASIC_USER: 'admin', BASIC_PASS: 'secret' },
+      request: new Request('https://example.com/api/manage/list'),
+    }));
+
+    assert.strictEqual(res.status, 401);
+    assert.strictEqual(res.headers.get('WWW-Authenticate'), 'Basic realm="my scope", charset="UTF-8"');
+  });
+
+  it('allows dashboard requests with valid basic auth credentials', async function () {
+    const authentication = await getAuthentication();
+    const img_url = createMockKV();
+    const headers = new Headers({
+      Authorization: `Basic ${btoa('admin:secret')}`,
+    });
+
+    const res = await authentication(makeContext({
+      env: { img_url, BASIC_USER: 'admin', BASIC_PASS: 'secret' },
+      request: new Request('https://example.com/api/manage/list', { headers }),
+      next: async () => new Response('ok'),
+    }));
+
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(await res.text(), 'ok');
+  });
+
+  it('returns the dashboard disabled message when KV is not bound', async function () {
+    const authentication = await getAuthentication();
+
+    const res = await authentication(makeContext({
+      env: { BASIC_USER: 'admin', BASIC_PASS: 'secret' },
+      request: new Request('https://example.com/api/manage/list'),
+    }));
+
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(await res.text(), 'Dashboard is disabled. Please bind a KV namespace to use this feature.');
+  });
+});

--- a/test/pagination.test.js
+++ b/test/pagination.test.js
@@ -45,4 +45,28 @@ describe('KV list pagination', function () {
     assert.strictEqual(secondData.list_complete, true);
     assert.ok(!secondData.cursor);
   });
+
+  it('clamps invalid limits and forwards prefix filters', async function () {
+    const onRequest = await getOnRequest();
+    let observedOptions;
+    const env = {
+      img_url: {
+        list: options => {
+          observedOptions = options;
+          return Promise.resolve({ keys: [], list_complete: true });
+        }
+      }
+    };
+
+    const request = new Request('https://example.com/api/manage/list?limit=2000&prefix=avatar');
+    const res = await onRequest({ request, env });
+    const data = JSON.parse(await res.text());
+
+    assert.deepStrictEqual(data, { keys: [], list_complete: true });
+    assert.deepStrictEqual(observedOptions, {
+      limit: 1000,
+      cursor: undefined,
+      prefix: 'avatar'
+    });
+  });
 });

--- a/test/upload.test.js
+++ b/test/upload.test.js
@@ -1,0 +1,155 @@
+const assert = require('assert');
+const { createMockKV, installFetchMock, makeContext, muteConsole } = require('./helpers');
+
+describe('upload function', function () {
+  let restoreConsole;
+  let fetchMock;
+
+  beforeEach(function () {
+    restoreConsole = muteConsole();
+  });
+
+  afterEach(function () {
+    if (fetchMock) {
+      fetchMock.restore();
+      fetchMock = null;
+    }
+    restoreConsole();
+  });
+
+  async function createUploadRequest(file) {
+    const formData = new FormData();
+    formData.append('file', file);
+
+    return new Request('https://example.com/upload', {
+      method: 'POST',
+      body: formData,
+    });
+  }
+
+  it('uploads images with sendPhoto and stores metadata in KV', async function () {
+    const { onRequestPost } = await import('../functions/upload.js');
+    const img_url = createMockKV();
+
+    fetchMock = installFetchMock(async (input, init) => {
+      assert.strictEqual(String(input), 'https://api.telegram.org/botbot-token/sendPhoto');
+      assert.strictEqual(init.method, 'POST');
+      assert.strictEqual(init.body.get('chat_id'), '-100123');
+      assert.ok(init.body.get('photo') instanceof File);
+
+      return Response.json({
+        ok: true,
+        result: {
+          photo: [
+            { file_id: 'small-id', file_size: 10 },
+            { file_id: 'large-id', file_size: 20 },
+          ],
+        },
+      });
+    });
+
+    const request = await createUploadRequest(new File(['image-bytes'], 'cat.png', { type: 'image/png' }));
+    const res = await onRequestPost(makeContext({
+      request,
+      env: {
+        disable_telemetry: 'true',
+        TG_Bot_Token: 'bot-token',
+        TG_Chat_ID: '-100123',
+        img_url,
+      },
+    }));
+
+    assert.strictEqual(res.status, 200);
+    assert.deepStrictEqual(JSON.parse(await res.text()), [{ src: '/file/large-id.png' }]);
+    assert.strictEqual(fetchMock.calls.length, 1);
+
+    const stored = img_url.snapshot('large-id.png');
+    assert.strictEqual(stored.value, '');
+    assert.strictEqual(stored.metadata.ListType, 'None');
+    assert.strictEqual(stored.metadata.Label, 'None');
+    assert.strictEqual(stored.metadata.fileName, 'cat.png');
+    assert.strictEqual(stored.metadata.fileSize, 11);
+    assert.strictEqual(stored.metadata.liked, false);
+    assert.ok(Number.isFinite(stored.metadata.TimeStamp));
+  });
+
+  it('retries failed image uploads as documents', async function () {
+    const { onRequestPost } = await import('../functions/upload.js');
+
+    fetchMock = installFetchMock(async (input, init, calls) => {
+      if (calls.length === 1) {
+        assert.strictEqual(String(input), 'https://api.telegram.org/botbot-token/sendPhoto');
+        assert.ok(init.body.get('photo') instanceof File);
+        return Response.json({ ok: false, description: 'Bad Request: wrong file identifier' }, { status: 400 });
+      }
+
+      assert.strictEqual(String(input), 'https://api.telegram.org/botbot-token/sendDocument');
+      assert.ok(init.body.get('document') instanceof File);
+      return Response.json({
+        ok: true,
+        result: {
+          document: { file_id: 'doc-id' },
+        },
+      });
+    });
+
+    const request = await createUploadRequest(new File(['image-bytes'], 'cat.webp', { type: 'image/webp' }));
+    const res = await onRequestPost(makeContext({
+      request,
+      env: {
+        disable_telemetry: 'true',
+        TG_Bot_Token: 'bot-token',
+        TG_Chat_ID: '-100123',
+      },
+    }));
+
+    assert.strictEqual(res.status, 200);
+    assert.deepStrictEqual(JSON.parse(await res.text()), [{ src: '/file/doc-id.webp' }]);
+    assert.strictEqual(fetchMock.calls.length, 2);
+  });
+
+  it('uploads non-media files with sendDocument', async function () {
+    const { onRequestPost } = await import('../functions/upload.js');
+
+    fetchMock = installFetchMock(async (input, init) => {
+      assert.strictEqual(String(input), 'https://api.telegram.org/botbot-token/sendDocument');
+      assert.strictEqual(init.body.get('chat_id'), '-100123');
+      assert.ok(init.body.get('document') instanceof File);
+      return Response.json({
+        ok: true,
+        result: {
+          document: { file_id: 'doc-id' },
+        },
+      });
+    });
+
+    const request = await createUploadRequest(new File(['hello'], 'notes.txt', { type: 'text/plain' }));
+    const res = await onRequestPost(makeContext({
+      request,
+      env: {
+        disable_telemetry: 'true',
+        TG_Bot_Token: 'bot-token',
+        TG_Chat_ID: '-100123',
+      },
+    }));
+
+    assert.strictEqual(res.status, 200);
+    assert.deepStrictEqual(JSON.parse(await res.text()), [{ src: '/file/doc-id.txt' }]);
+  });
+
+  it('returns a JSON error when the upload form has no file field', async function () {
+    const { onRequestPost } = await import('../functions/upload.js');
+    const request = new Request('https://example.com/upload', {
+      method: 'POST',
+      body: new FormData(),
+    });
+
+    const res = await onRequestPost(makeContext({
+      request,
+      env: { disable_telemetry: 'true' },
+    }));
+
+    assert.strictEqual(res.status, 500);
+    assert.deepStrictEqual(JSON.parse(await res.text()), { error: 'No file uploaded' });
+  });
+});


### PR DESCRIPTION
## Summary
- add focused tests for upload, file proxy, manage APIs, pagination, and dashboard auth middleware
- extract shared function helpers for HTTP responses, metadata handling, Telegram Bot API calls, and Basic Auth
- refactor upload, file proxy, and manage API functions to use the shared helpers
- fix admin display-name editing by reading the existing newName query parameter

## Tests
- npm test